### PR TITLE
feat: add media image resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,12 @@
   ```
 
 ## Checks
-- Run linting with `uv run ruff .`.
+- Run linting with `uv run ruff check .`.
 - Run the test suite with `uv run pytest` and ensure it passes before committing.
+
+## Efficiency and Search
+- Use `rg` (ripgrep) for recursive search.
+- Avoid `ls -R` and `grep -R` as they generate excessive output.
 
 ## Git Commit Guidelines
 - Commit messages must follow [Conventional Commit](https://www.conventionalcommits.org/) standards.

--- a/mcp_plex/server.py
+++ b/mcp_plex/server.py
@@ -144,5 +144,45 @@ async def recommend_media(
     return [r.payload["data"] for r in recs]
 
 
+@server.resource("resource://media-poster/{identifier}")
+async def media_poster(
+    identifier: Annotated[
+        str,
+        Field(
+            description="Rating key, IMDb/TMDb ID, or media title",
+            examples=["49915", "tt8367814", "The Gentlemen"],
+        ),
+    ],
+) -> str:
+    """Return the poster image URL for the given media identifier."""
+    records = await _find_records(identifier, limit=1)
+    if not records:
+        raise ValueError("Media item not found")
+    thumb = records[0].payload["data"].get("plex", {}).get("thumb")
+    if not thumb:
+        raise ValueError("Poster not available")
+    return thumb
+
+
+@server.resource("resource://media-background/{identifier}")
+async def media_background(
+    identifier: Annotated[
+        str,
+        Field(
+            description="Rating key, IMDb/TMDb ID, or media title",
+            examples=["49915", "tt8367814", "The Gentlemen"],
+        ),
+    ],
+) -> str:
+    """Return the background art URL for the given media identifier."""
+    records = await _find_records(identifier, limit=1)
+    if not records:
+        raise ValueError("Media item not found")
+    art = records[0].payload["data"].get("plex", {}).get("art")
+    if not art:
+        raise ValueError("Background not available")
+    return art
+
+
 if __name__ == "__main__":  # pragma: no cover
     server.run()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@ import asyncio
 from pathlib import Path
 import importlib
 import types
+import pytest
 
 from mcp_plex import loader
 from qdrant_client import models
@@ -151,3 +152,15 @@ def test_server_tools(tmp_path, monkeypatch):
 
     # Exercise search path with an ID that doesn't exist
     asyncio.run(server._find_records("12345", limit=1))
+
+    poster = asyncio.run(server.media_poster.fn(identifier=movie_id))
+    assert isinstance(poster, str) and "thumb" in poster
+
+    art = asyncio.run(server.media_background.fn(identifier=movie_id))
+    assert isinstance(art, str) and "art" in art
+
+    with pytest.raises(ValueError):
+        asyncio.run(server.media_poster.fn(identifier="0"))
+
+    with pytest.raises(ValueError):
+        asyncio.run(server.media_background.fn(identifier="0"))

--- a/uv.lock
+++ b/uv.lock
@@ -789,7 +789,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.1.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What
- add MCP resources for media poster and background image URLs
- rely on fastmcp and qdrant-client packages instead of local stubs
- update lockfile to match project version

## Why
- expose media artwork through the MCP interface
- depend on real packages managed by `uv`

## Affects
- server resource surface
- dependency handling and lockfile

## Testing
- `uv run ruff check .`
- `uv run --extra dev python -m pytest`

## Documentation
- none


------
https://chatgpt.com/codex/tasks/task_e_68b3dadfef248328909f0d350aa0620e