### PR TITLE
fix: populate click option metadata

### DIFF
--- a/mcp_plex/loader.py
+++ b/mcp_plex/loader.py
@@ -415,24 +415,61 @@ async def run(
 
 
 @click.command()
-@click.option("--plex-url", envvar="PLEX_URL", help="Plex base URL")
-@click.option("--plex-token", envvar="PLEX_TOKEN", help="Plex API token")
-@click.option("--tmdb-api-key", envvar="TMDB_API_KEY", help="TMDb API key")
-@click.option("--sample-dir", type=click.Path(path_type=Path))
-@click.option("--qdrant-url", envvar="QDRANT_URL", help="Qdrant URL or path")
-@click.option("--qdrant-api-key", envvar="QDRANT_API_KEY", help="Qdrant API key")
+@click.option(
+    "--plex-url",
+    envvar="PLEX_URL",
+    show_envvar=True,
+    required=True,
+    help="Plex base URL",
+)
+@click.option(
+    "--plex-token",
+    envvar="PLEX_TOKEN",
+    show_envvar=True,
+    required=True,
+    help="Plex API token",
+)
+@click.option(
+    "--tmdb-api-key",
+    envvar="TMDB_API_KEY",
+    show_envvar=True,
+    required=True,
+    help="TMDb API key",
+)
+@click.option(
+    "--sample-dir",
+    type=click.Path(path_type=Path),
+    required=False,
+    help="Directory containing sample data instead of live Plex access",
+)
+@click.option(
+    "--qdrant-url",
+    envvar="QDRANT_URL",
+    show_envvar=True,
+    required=False,
+    help="Qdrant URL or path",
+)
+@click.option(
+    "--qdrant-api-key",
+    envvar="QDRANT_API_KEY",
+    show_envvar=True,
+    required=False,
+    help="Qdrant API key",
+)
 @click.option(
     "--continuous",
     is_flag=True,
     help="Continuously run the loader",
     show_default=True,
     default=False,
+    required=False,
 )
 @click.option(
     "--delay",
     type=float,
     default=300.0,
     show_default=True,
+    required=False,
     help="Delay between runs in seconds when using --continuous",
 )
 def main(

--- a/tests/test_loader_cli.py
+++ b/tests/test_loader_cli.py
@@ -24,14 +24,31 @@ def test_cli_continuous_respects_delay(monkeypatch):
 
     runner = CliRunner()
     with pytest.raises(RuntimeError, match="stop"):
-        runner.invoke(loader.main, ["--continuous", "--delay", "7.5"], catch_exceptions=False)
+        runner.invoke(
+            loader.main,
+            ["--continuous", "--delay", "7.5"],
+            catch_exceptions=False,
+            env={
+                "PLEX_URL": "http://localhost",
+                "PLEX_TOKEN": "token",
+                "TMDB_API_KEY": "key",
+            },
+        )
 
     assert actions == ["run", ("sleep", 7.5), "run"]
 
 
 def test_cli_invalid_delay_value():
     runner = CliRunner()
-    result = runner.invoke(loader.main, ["--delay", "not-a-number"])
+    result = runner.invoke(
+        loader.main,
+        ["--delay", "not-a-number"],
+        env={
+            "PLEX_URL": "http://localhost",
+            "PLEX_TOKEN": "token",
+            "TMDB_API_KEY": "key",
+        },
+    )
     assert result.exit_code != 0
     assert "Invalid value for '--delay'" in result.output
 


### PR DESCRIPTION
## What
- add required, envvar, and help metadata for CLI options
- supply required credentials in CLI tests

## Why
- click arguments lacked required metadata, reducing help clarity

## Affects
- CLI option definitions for loader
- tests verifying loader CLI

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- none


------
https://chatgpt.com/codex/tasks/task_e_68b3e24cbdac8328a0439f9012626866