### PR TITLE
fix: harden sample request scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.2.2"
+version = "0.3.0"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<4"

--- a/sample-data/requests/plex-curl.sh
+++ b/sample-data/requests/plex-curl.sh
@@ -1,2 +1,11 @@
 #!/bin/bash
-curl -H 'Accept: application/json' "$PLEX_URL/library/metadata/61960?checkFiles=1&includeAllConcerts=1&includeBandwidths=1&includeChapters=1&includeChildren=1&includeConcerts=1&includeExtras=1&includeFields=1&includeGeolocation=1&includeLoudnessRamps=1&includeMarkers=1&includeOnDeck=1&includePopularLeaves=1&includePreferences=1&includeRelated=1&includeRelatedCount=1&includeReviews=1&includeStations=1&X-Plex-Token=$PLEX_TOKENincludeGuids=1&includeReviews=1"
+set -euo pipefail
+
+if [[ -z "${PLEX_URL:-}" || -z "${PLEX_TOKEN:-}" ]]; then
+  echo "PLEX_URL and PLEX_TOKEN must be set" >&2
+  exit 1
+fi
+
+curl -H 'Accept: application/json' \
+  "$PLEX_URL/library/metadata/61960?checkFiles=1&includeAllConcerts=1&includeBandwidths=1&includeChapters=1&includeChildren=1&includeConcerts=1&includeExtras=1&includeFields=1&includeGeolocation=1&includeLoudnessRamps=1&includeMarkers=1&includeOnDeck=1&includePopularLeaves=1&includePreferences=1&includeRelated=1&includeRelatedCount=1&includeReviews=1&includeStations=1&includeGuids=1&X-Plex-Token=$PLEX_TOKEN"
+

--- a/sample-data/requests/tmdb-curl.sh
+++ b/sample-data/requests/tmdb-curl.sh
@@ -1,2 +1,11 @@
 #!/bin/bash
-curl -H 'Authorization: Bearer $TMDB_TOKEN' -H 'Accept: application/json' 'https://api.themoviedb.org/3/tv/157239?append_to_response=reviews,actors,directors,writers'
+set -euo pipefail
+
+if [[ -z "${TMDB_API_KEY:-}" ]]; then
+  echo "TMDB_API_KEY must be set" >&2
+  exit 1
+fi
+
+curl -H "Authorization: Bearer $TMDB_API_KEY" -H 'Accept: application/json' \
+  'https://api.themoviedb.org/3/tv/157239?append_to_response=reviews,actors,directors,writers'
+

--- a/uv.lock
+++ b/uv.lock
@@ -789,7 +789,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What
- add strict error handling and env validation to sample request scripts
- bump version to 0.3.0

## Why
- ensure scripts fail fast when required variables are missing
- prepare next minor release

## Affects
- sample-data/requests
- pyproject version

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- not needed
