### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.3.0"
+version = "0.4.0"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -789,7 +789,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What
- bump project version to 0.4.0

## Why
- reflect new features since 0.3.0, including configurable Qdrant connection and CLI transport options

## Affects
- project metadata (pyproject, lockfile)

## Testing
- `uv sync --extra dev`
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- no docs needed

------
https://chatgpt.com/codex/tasks/task_e_68bf95daae348328be43e307dbe9e74e