### PR TITLE
chore: bump version to 0.4.1 and clarify versioning policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
   ```
 
 ## Versioning
-- Bump the version in `pyproject.toml` for any user-facing change.
+- Always bump the version in `pyproject.toml` for any change.
 - Update `uv.lock` after version or dependency changes by running `uv lock`.
 
 ## Checks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.4.0"
+version = "0.4.1"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What
- clarify versioning policy to bump version for all changes
- bump project version to 0.4.1

## Why
- maintain explicit version updates regardless of change type

## Affects
- AGENTS.md
- pyproject.toml
- uv.lock

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- updated AGENTS.md


------
https://chatgpt.com/codex/tasks/task_e_68bfa1a4134083288fb7340f9b380de5