### PR TITLE
feat: add loader service and universal entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN uv sync --no-dev
 COPY . .
-
-ENTRYPOINT ["uv", "run", "load-data"]
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["load-data"]

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ uv run load-data --continuous --delay 600
 ### Run the MCP Server
 Start the FastMCP server over stdio (default):
 ```bash
-uv run python -m mcp_plex.server
+uv run mcp-server
 ```
 Expose the server over SSE on port 8000:
 ```bash
-uv run python -m mcp_plex.server --transport sse --bind 0.0.0.0 --port 8000 --mount /mcp
+uv run mcp-server --transport sse --bind 0.0.0.0 --port 8000 --mount /mcp
 ```
 
 ## Docker
@@ -64,7 +64,7 @@ The included `docker-compose.yml` launches both Qdrant and the MCP server.
    ```
 3. (Optional) Load sample data into Qdrant:
    ```bash
-   docker compose run --rm mcp-plex uv run load-data --sample-dir sample-data
+   docker compose run --rm loader load-data --sample-dir sample-data
    ```
 
 The server will connect to the `qdrant` service at `http://qdrant:6333` and

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,16 @@ services:
     image: qdrant/qdrant
     ports:
       - "6333:6333"
+  loader:
+    build: .
+    environment:
+      PLEX_URL: ${PLEX_URL}
+      PLEX_TOKEN: ${PLEX_TOKEN}
+      TMDB_API_KEY: ${TMDB_API_KEY}
+      QDRANT_URL: http://qdrant:6333
+    depends_on:
+      - qdrant
+    command: load-data --continuous
   mcp-plex:
     build: .
     environment:
@@ -14,6 +24,6 @@ services:
       QDRANT_URL: http://qdrant:6333
     depends_on:
       - qdrant
-    command: uv run python -m mcp_plex.server --transport sse --bind 0.0.0.0 --port 8000 --mount /mcp
+    command: mcp-server --transport sse --bind 0.0.0.0 --port 8000 --mount /mcp
     ports:
       - "8000:8000"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -e
+
+exec uv run "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.4.1"
+version = "0.4.2"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<4"
@@ -27,6 +27,7 @@ dev = [
 
 [project.scripts]
 load-data = "mcp_plex.loader:main"
+mcp-server = "mcp_plex.server:main"
 
 [[tool.uv.index]]
 url = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/"

--- a/uv.lock
+++ b/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What
- add `mcp-server` uv script
- introduce universal `entrypoint.sh` for Docker image
- run loader alongside server in `docker-compose`
- document new commands

## Why
- allow container to run either the loader or server from the same image
- make docker-compose orchestrate data loading and server simultaneously

## Affects
- Dockerfile, docker-compose, entrypoint, pyproject, README, lock file

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- updated README.md

------
https://chatgpt.com/codex/tasks/task_e_68bfaae467148328be3fcb2244e4f6c9