### PR TITLE
fix(ci): run docker workflow only on released events

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,8 +4,8 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   release:
-    type:
-      - created
+    types:
+      - released
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.4.2"
+version = "0.4.3"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What
- trigger Docker publish workflow only when a GitHub release is actually released
- bump package version to 0.4.3

## Why
- avoid running the Docker build on release creation or deletion

## Affects
- CI/CD workflow for Docker image publishing
- project versioning

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- none required

------
https://chatgpt.com/codex/tasks/task_e_68bfad0d95848328bc28b52e05142950