### PR TITLE
feat: expand qdrant indexing and add actor-based queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,22 @@
 # AGENTS
 
+## Architecture
+- `mcp_plex/loader.py` ingests Plex, TMDb, and IMDb metadata, builds dense and sparse embeddings, and stores items in a Qdrant collection.
+- `mcp_plex/server.py` exposes retrieval and search tools via FastMCP backed by Qdrant.
+- `mcp_plex/types.py` defines the Pydantic models used across the project.
+- When making architectural design decisions, add a short note here describing the decision and its rationale.
+- Actor names are stored as a top-level payload field and indexed in Qdrant to enable actor and year-based filtering.
+
+## User Queries
+The project should handle natural-language searches and recommendations such as:
+- "What's that show that had the billionaire that invited the artist and the journalist and the musician to his house and ended up with an alien that breaks free from a meteor?"
+- "Find a horror movie similar to Schindler's List"
+- "Recommend an action comedy movie with Tom Holland"
+- "What new movies do I have?"
+- "Any new shows?"
+- "Find the newest movie with Tom Cruise"
+- "Suggest a movie from the 90's with Glenn Close"
+
 ## Dependency Management
 - Use [uv](https://github.com/astral-sh/uv) for all Python dependency management and command execution.
 - Install project and development dependencies with:

--- a/mcp_plex/types.py
+++ b/mcp_plex/types.py
@@ -121,6 +121,7 @@ class PlexItem(BaseModel):
     title: str
     summary: Optional[str] = None
     year: Optional[int] = None
+    added_at: Optional[int] = None
     guids: List[PlexGuid] = Field(default_factory=list)
     thumb: Optional[str] = None
     art: Optional[str] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.4.3"
+version = "0.4.6"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<4"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -102,6 +102,34 @@ def test_server_tools(monkeypatch):
         asyncio.run(server.media_background.fn(identifier="0"))
 
 
+def test_new_media_tools(monkeypatch):
+    server = _load_server(monkeypatch)
+
+    movies = asyncio.run(server.new_movies.fn(limit=1))
+    assert movies and movies[0]["plex"]["type"] == "movie"
+    assert movies[0]["plex"]["added_at"] is not None
+
+    shows = asyncio.run(server.new_shows.fn(limit=1))
+    assert shows and shows[0]["plex"]["type"] == "episode"
+    assert shows[0]["plex"]["added_at"] is not None
+
+
+def test_actor_movies(monkeypatch):
+    server = _load_server(monkeypatch)
+
+    movies = asyncio.run(
+        server.actor_movies.fn(actor="Matthew McConaughey", limit=1)
+    )
+    assert movies and movies[0]["plex"]["title"] == "The Gentlemen"
+
+    none = asyncio.run(
+        server.actor_movies.fn(
+            actor="Matthew McConaughey", year_from=1990, year_to=1999
+        )
+    )
+    assert none == []
+
+
 def test_reranker_import_failure(monkeypatch):
     monkeypatch.setenv("USE_RERANKER", "1")
     orig_import = builtins.__import__

--- a/uv.lock
+++ b/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.4.3"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What
- document actor indexing and new query examples in `AGENTS.md`
- index actor names in Qdrant and store them in payloads
- add `actor-movies` server tool for filtering movies by actor and year
- test actor-based movie retrieval
- bump version to 0.4.6

## Why
- support queries like "Find the newest movie with Tom Cruise" and "Suggest a movie from the 90's with Glenn Close"

## Affects
- `AGENTS.md`
- `mcp_plex/loader.py`
- `mcp_plex/server.py`
- `tests/test_server.py`
- `pyproject.toml`
- `uv.lock`

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- Updated `AGENTS.md` with actor indexing and new example queries

------
https://chatgpt.com/codex/tasks/task_e_68bfb020dc348328921da2402c278135