### PR TITLE
feat: compute embeddings through qdrant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.0"
+version = "0.26.1"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<4"

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -2,28 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-class _StubDense:
-    def __init__(self, *args, **kwargs) -> None:
-        pass
-
-    @staticmethod
-    def list_supported_models() -> list[str]:
-        return ["stub-dense"]
-
-
-class _StubSparse:
-    def __init__(self, *args, **kwargs) -> None:
-        pass
-
-    @staticmethod
-    def list_supported_models() -> list[str]:
-        return ["stub"]
-
-
-with patch("fastembed.TextEmbedding", _StubDense), patch(
-    "fastembed.SparseTextEmbedding", _StubSparse
-):
-    from mcp_plex import server
+from mcp_plex import server
 
 
 def test_main_stdio_runs():
@@ -51,32 +30,26 @@ def test_main_http_with_mount_runs():
 
 
 def test_main_model_overrides():
-    with patch("mcp_plex.server.TextEmbedding") as mock_dense, patch(
-        "mcp_plex.server.SparseTextEmbedding"
-    ) as mock_sparse, patch.object(server.server, "run") as mock_run:
+    with patch.object(server.server, "run") as mock_run:
         server.main([
             "--dense-model",
             "foo",
             "--sparse-model",
             "bar",
         ])
-        mock_dense.assert_called_with("foo")
-        mock_sparse.assert_called_with("bar")
+        assert server._DENSE_MODEL_NAME == "foo"
+        assert server._SPARSE_MODEL_NAME == "bar"
         mock_run.assert_called_once_with(transport="stdio")
 
 
 def test_env_model_overrides(monkeypatch):
-    with patch("fastembed.TextEmbedding") as mock_dense, patch(
-        "fastembed.SparseTextEmbedding"
-    ) as mock_sparse:
-        monkeypatch.setenv("DENSE_MODEL", "foo")
-        monkeypatch.setenv("SPARSE_MODEL", "bar")
-        import importlib
+    monkeypatch.setenv("DENSE_MODEL", "foo")
+    monkeypatch.setenv("SPARSE_MODEL", "bar")
+    import importlib
 
-        importlib.reload(server)
-        mock_dense.assert_called_with("foo")
-        mock_sparse.assert_called_with("bar")
-    with patch("fastembed.TextEmbedding"), patch("fastembed.SparseTextEmbedding"):
-        import importlib
+    importlib.reload(server)
+    assert server._DENSE_MODEL_NAME == "foo"
+    assert server._SPARSE_MODEL_NAME == "bar"
 
-        importlib.reload(server)
+    # reload to reset globals
+    importlib.reload(server)

--- a/uv.lock
+++ b/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.0"
+version = "0.26.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What
- remove direct fastembed model usage from server
- delegate search embedding to Qdrant Fastembed using Document inputs
- bump version to 0.26.1

## Why
- use Qdrant's built-in embedding support instead of managing models manually

## Affects
- mcp_plex/server.py
- tests/test_server_cli.py
- pyproject.toml, uv.lock

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68c57e90bdc0832890da728a3a59f533