### PR TITLE
feat(server): use Qdrant fusion query for hybrid search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@
 - Actor names are stored as a top-level payload field and indexed in Qdrant to enable actor and year-based filtering.
 - Dense and sparse embedding model names are configurable via `DENSE_MODEL` and
   `SPARSE_MODEL` environment variables or the corresponding CLI options.
+- Hybrid search uses Qdrant's built-in `FusionQuery` with reciprocal rank fusion
+  to combine dense and sparse results before optional cross-encoder reranking.
 
 ## User Queries
 The project should handle natural-language searches and recommendations such as:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.3"
+version = "0.26.4"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -676,7 +676,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.3"
+version = "0.26.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What
- replace manual dense+sparse fusion with Qdrant `FusionQuery`
- document hybrid search approach in `AGENTS.md`
- bump version to 0.26.4

## Why
- align hybrid search with Qdrant's recommended reranking workflow

## Affects
- `mcp_plex/server.py`
- project metadata

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- `AGENTS.md` updated

------
https://chatgpt.com/codex/tasks/task_e_68c589575c788328ae52a57717a65f26