### PR TITLE
feat: expose MCP components via REST

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.5"
+version = "0.26.6"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.4"
+version = "0.26.5"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",
+  "fastapi>=0.115.0",
   "pydantic>=2.11.7",
   "plexapi>=4.17.0",
   "qdrant-client[fastembed-gpu]>=1.15.1",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import builtins
 import pytest
+from starlette.testclient import TestClient
 
 from mcp_plex import loader
 
@@ -156,3 +157,19 @@ def test_reranker_init_failure(monkeypatch):
     monkeypatch.setitem(sys.modules, "sentence_transformers", st_module)
     server = importlib.reload(importlib.import_module("mcp_plex.server"))
     assert server._reranker is None
+
+
+def test_rest_endpoints(monkeypatch):
+    module = _load_server(monkeypatch)
+    client = TestClient(module.server.http_app())
+
+    resp = client.post("/rest/tool/get-media", json={"identifier": "49915"})
+    assert resp.status_code == 200
+    assert resp.json()[0]["plex"]["rating_key"] == "49915"
+
+    resp = client.get("/rest/resource/media-item/49915")
+    assert resp.status_code == 200
+    assert resp.json()["plex"]["rating_key"] == "49915"
+
+    resp = client.get("/rest")
+    assert resp.status_code == 200

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -163,13 +163,15 @@ def test_rest_endpoints(monkeypatch):
     module = _load_server(monkeypatch)
     client = TestClient(module.server.http_app())
 
-    resp = client.post("/rest/tool/get-media", json={"identifier": "49915"})
+    resp = client.post("/rest/get-media", json={"identifier": "49915"})
     assert resp.status_code == 200
     assert resp.json()[0]["plex"]["rating_key"] == "49915"
 
-    resp = client.get("/rest/resource/media-item/49915")
-    assert resp.status_code == 200
-    assert resp.json()["plex"]["rating_key"] == "49915"
+    spec = client.get("/openapi.json").json()
+    get_media = spec["paths"]["/rest/get-media"]["post"]
+    assert get_media["description"].startswith("Retrieve media items")
+    params = {p["name"]: p for p in get_media["parameters"]}
+    assert params["identifier"]["schema"]["description"].startswith("Rating key")
 
     resp = client.get("/rest")
     assert resp.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.5"
+version = "0.26.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -265,6 +265,20 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.116.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/d7/6c8b3bfe33eeffa208183ec037fee0cce9f7f024089ab1c5d12ef04bd27c/fastapi-0.116.1.tar.gz", hash = "sha256:ed52cbf946abfd70c5a0dccb24673f0670deeb517a88b3544d03c2a6bf283143", size = 296485, upload-time = "2025-07-11T16:22:32.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/47/d63c60f59a59467fda0f93f46335c9d18526d7071f025cb5b89d5353ea42/fastapi-0.116.1-py3-none-any.whl", hash = "sha256:c46ac7c312df840f0c9e220f7964bada936781bc4e2e6eb71f1c4d7553786565", size = 95631, upload-time = "2025-07-11T16:22:30.485Z" },
+]
+
+[[package]]
 name = "fastembed-gpu"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -676,9 +690,10 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.4"
+version = "0.26.5"
 source = { editable = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "plexapi" },
@@ -697,6 +712,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastmcp", specifier = ">=2.11.2" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "plexapi", specifier = ">=4.17.0" },


### PR DESCRIPTION
## Summary
- add Swagger UI and generic REST routes for tools, prompts, and resources
- cover REST endpoints with integration test
- bump version to 0.26.5 and add fastapi dependency

## Testing
- `uv run ruff check mcp_plex/server.py tests/test_server.py`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c60bc95ed8832886c137a8d0968f97