### PR TITLE
feat(server): expose prompts and resources via dynamic REST endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.6"
+version = "0.26.7"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -167,11 +167,23 @@ def test_rest_endpoints(monkeypatch):
     assert resp.status_code == 200
     assert resp.json()[0]["plex"]["rating_key"] == "49915"
 
+    resp = client.post("/rest/prompt/media-info", json={"identifier": "49915"})
+    assert resp.status_code == 200
+    msg = resp.json()[0]
+    assert msg["role"] == "user"
+    assert "The Gentlemen" in msg["content"]["text"]
+
+    resp = client.get("/rest/resource/media-ids/49915")
+    assert resp.status_code == 200
+    assert resp.json()["rating_key"] == "49915"
+
     spec = client.get("/openapi.json").json()
     get_media = spec["paths"]["/rest/get-media"]["post"]
     assert get_media["description"].startswith("Retrieve media items")
     params = {p["name"]: p for p in get_media["parameters"]}
     assert params["identifier"]["schema"]["description"].startswith("Rating key")
+    assert "/rest/prompt/media-info" in spec["paths"]
+    assert "/rest/resource/media-ids/{identifier}" in spec["paths"]
 
     resp = client.get("/rest")
     assert resp.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.6"
+version = "0.26.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- dynamically mount prompts and resources as REST endpoints alongside tools
- add `media-info` prompt and cover REST prompt/resource in tests
- include prompts and resources in generated OpenAPI schema

## Why
- avoid bespoke routing by registering all MCP components through a single dynamic handler

## Affects
- `mcp_plex/server.py`
- `tests/test_server.py`
- `pyproject.toml`

## Testing
- `uv run ruff check .`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6152e803883289792172cf1fc1b49