### PR TITLE
feat(loader): batch metadata augmentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.7"
+version = "0.26.8"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_gather_in_batches.py
+++ b/tests/test_gather_in_batches.py
@@ -1,0 +1,26 @@
+import asyncio
+
+from mcp_plex import loader
+
+
+async def _echo(value: int) -> int:
+    await asyncio.sleep(0)
+    return value
+
+
+def test_gather_in_batches(monkeypatch):
+    calls: list[int] = []
+    orig_gather = asyncio.gather
+
+    async def fake_gather(*coros):
+        calls.append(len(coros))
+        return await orig_gather(*coros)
+
+    monkeypatch.setattr(asyncio, "gather", fake_gather)
+
+    tasks = [_echo(i) for i in range(5)]
+    results = asyncio.run(loader._gather_in_batches(tasks, 2))
+
+    assert results == list(range(5))
+    assert calls == [2, 2, 1]
+

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.7"
+version = "0.26.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- batch metadata augmentation when loading from Plex
- test helpers for batched gathering

## Why
- limit concurrent API calls during metadata augmentation

## Affects
- loader, tests, version

## Testing
- `uv sync --extra dev`
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68c62fe291408328b450b81d2419689a