### PR TITLE
refactor: initialize Qdrant client within PlexServer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@
   `SPARSE_MODEL` environment variables or the corresponding CLI options.
 - Hybrid search uses Qdrant's built-in `FusionQuery` with reciprocal rank fusion
   to combine dense and sparse results before optional cross-encoder reranking.
+- Qdrant client initialization moved into `PlexServer` to centralize state and
+  simplify testing.
 
 ## User Queries
 The project should handle natural-language searches and recommendations such as:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.9"
+version = "0.26.10"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -54,13 +54,14 @@ def test_qdrant_env_config(monkeypatch):
     monkeypatch.setenv("QDRANT_GRPC_PORT", "5678")
     monkeypatch.setenv("QDRANT_PREFER_GRPC", "1")
     monkeypatch.setenv("QDRANT_HTTPS", "1")
-    importlib.reload(importlib.import_module("mcp_plex.server"))
+    module = importlib.reload(importlib.import_module("mcp_plex.server"))
 
     assert captured["host"] == "example.com"
     assert captured["port"] == 1234
     assert captured["grpc_port"] == 5678
     assert captured["prefer_grpc"] is True
     assert captured["https"] is True
+    assert hasattr(module.server, "qdrant_client")
 
 
 def test_server_tools(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.9"
+version = "0.26.10"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- instantiate Qdrant client in `PlexServer` and expose as `server.qdrant_client`
- update server methods to use the new client attribute and adjust tests
- document architecture change and bump version to 0.26.10

## Why
- centralizes Qdrant client state on the server instance and simplifies testing

## Affects
- `mcp_plex/server.py`
- `tests/test_server.py`
- `AGENTS.md`, `pyproject.toml`

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- updated `AGENTS.md` to note the new client initialization location

------
https://chatgpt.com/codex/tasks/task_e_68c64a12d3b4832892a04829b0bcaa7b