### PR TITLE
feat: add configurable settings and Qdrant shutdown

### DIFF
--- a/mcp_plex/config.py
+++ b/mcp_plex/config.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application configuration settings."""
+
+    qdrant_url: str | None = Field(default=None, env="QDRANT_URL")
+    qdrant_api_key: str | None = Field(default=None, env="QDRANT_API_KEY")
+    qdrant_host: str | None = Field(default=None, env="QDRANT_HOST")
+    qdrant_port: int = Field(default=6333, env="QDRANT_PORT")
+    qdrant_grpc_port: int = Field(default=6334, env="QDRANT_GRPC_PORT")
+    qdrant_prefer_grpc: bool = Field(default=False, env="QDRANT_PREFER_GRPC")
+    qdrant_https: bool | None = Field(default=None, env="QDRANT_HTTPS")
+    dense_model: str = Field(
+        default="BAAI/bge-small-en-v1.5", env="DENSE_MODEL"
+    )
+    sparse_model: str = Field(
+        default="Qdrant/bm42-all-minilm-l6-v2-attentions", env="SPARSE_MODEL"
+    )
+    cache_size: int = Field(default=128, env="CACHE_SIZE")
+    use_reranker: bool = Field(default=True, env="USE_RERANKER")
+
+    model_config = SettingsConfigDict(case_sensitive=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.11"
+version = "0.26.12"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.11"
+version = "0.26.12"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- add `Settings` config model
- allow injecting `AsyncQdrantClient` into `PlexServer` and close it on shutdown
- drive model names and Qdrant options from settings
- ensure tests and server shutdown close the client

## Why
- enables dependency injection for easier testing
- avoids leaking Qdrant connections
- centralizes environment configuration

## Affects
- `mcp_plex.server`
- `mcp_plex.config`
- tests for server and CLI

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- none


------
https://chatgpt.com/codex/tasks/task_e_68c64efc6df88328ad2ee1c5b8ee15f6