### PR TITLE
fix(loader): use proper TMDB episode endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.12"
+version = "0.26.13"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_load_from_plex.py
+++ b/tests/test_load_from_plex.py
@@ -31,6 +31,8 @@ def test_load_from_plex(monkeypatch):
             guid="plex://episode/102",
             type="episode",
             title="Pilot",
+            parentIndex=1,
+            index=1,
             guids=[
                 types.SimpleNamespace(id="imdb://tt0959621"),
                 types.SimpleNamespace(id="tmdb://62085"),
@@ -95,10 +97,10 @@ def test_load_from_plex(monkeypatch):
             )
         if "/movie/27205" in url:
             return httpx.Response(200, json={"id": 27205, "title": "Inception"})
+        if "/tv/1396/season/1/episode/1" in url:
+            return httpx.Response(200, json={"id": 62085, "name": "Pilot"})
         if "/tv/1396" in url:
             return httpx.Response(200, json={"id": 1396, "name": "Breaking Bad"})
-        if "/episode/62085" in url:
-            return httpx.Response(200, json={"id": 62085, "name": "Pilot"})
         return httpx.Response(404)
 
     transport = httpx.MockTransport(handler)

--- a/tests/test_loader_unit.py
+++ b/tests/test_loader_unit.py
@@ -96,7 +96,7 @@ def test_fetch_functions_success_and_failure():
 
     async def tmdb_episode_mock(request):
         assert request.headers.get("Authorization") == "Bearer k"
-        if "good" in str(request.url):
+        if "/tv/1/season/2/episode/3" in str(request.url):
             return httpx.Response(200, json={"id": 1, "name": "E"})
         return httpx.Response(404)
 
@@ -119,7 +119,7 @@ def test_fetch_functions_success_and_failure():
             assert (await _fetch_tmdb_show(client, "bad", "k")) is None
 
         async with httpx.AsyncClient(transport=episode_transport) as client:
-            assert (await _fetch_tmdb_episode(client, "good", "k")) is not None
-            assert (await _fetch_tmdb_episode(client, "bad", "k")) is None
+            assert (await _fetch_tmdb_episode(client, 1, 2, 3, "k")) is not None
+            assert (await _fetch_tmdb_episode(client, 1, 2, 4, "k")) is None
 
     asyncio.run(main())

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.12"
+version = "0.26.13"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- fetch TMDB episode data via tv/{series}/season/{season}/episode/{episode}
- derive season and episode numbers from Plex metadata
- adjust tests for new episode API

## Testing
- `uv run ruff check .`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c653fcd5808328b48e3a5fb376e003