### PR TITLE
feat: cache IMDb responses with retries

### DIFF
--- a/mcp_plex/imdb_cache.py
+++ b/mcp_plex/imdb_cache.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+class IMDbCache:
+    """Simple persistent cache for IMDb API responses."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._data: Dict[str, Any]
+        if path.exists():
+            try:
+                self._data = json.loads(path.read_text())
+            except Exception:
+                self._data = {}
+        else:
+            self._data = {}
+
+    def get(self, imdb_id: str) -> dict[str, Any] | None:
+        """Return cached data for ``imdb_id`` if present."""
+
+        return self._data.get(imdb_id)
+
+    def set(self, imdb_id: str, data: dict[str, Any]) -> None:
+        """Store ``data`` under ``imdb_id`` and persist to disk."""
+
+        self._data[imdb_id] = data
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self._data))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.13"
+version = "0.26.14"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_loader_cli.py
+++ b/tests/test_loader_cli.py
@@ -68,8 +68,8 @@ def test_cli_model_overrides(monkeypatch):
     captured: dict[str, str] = {}
 
     async def fake_run(*args, **kwargs):
-        captured["dense"] = args[-2]
-        captured["sparse"] = args[-1]
+        captured["dense"] = args[11]
+        captured["sparse"] = args[12]
 
     monkeypatch.setattr(loader, "run", fake_run)
 
@@ -93,8 +93,8 @@ def test_cli_model_env(monkeypatch):
     captured: dict[str, str] = {}
 
     async def fake_run(*args, **kwargs):
-        captured["dense"] = args[-2]
-        captured["sparse"] = args[-1]
+        captured["dense"] = args[11]
+        captured["sparse"] = args[12]
 
     monkeypatch.setattr(loader, "run", fake_run)
 

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.13"
+version = "0.26.14"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- persist IMDb API responses to a JSON cache
- retry IMDb requests with exponential backoff on 429 responses
- expose CLI options/env vars for IMDb cache path and retry settings
- test cache hits/misses and 429 retry behaviour

## Why
- reduce repeated IMDb requests and respect API rate limits

## Affects
- `mcp_plex.loader`
- `mcp_plex.imdb_cache`
- tests

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- none


------
https://chatgpt.com/codex/tasks/task_e_68c6585baa408328b3f571b0a706ab58