### PR TITLE
feat: persist IMDb retry queue and fix TMDb season lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Run continuously with a delay between runs:
 uv run load-data --continuous --delay 600
 ```
 
+### IMDb Retry Queue
+When IMDb lookups continue to return HTTP 429 after the configured retries,
+their IDs are added to a small queue (`imdb_queue.json` by default). The queue
+is persisted after each run and reloaded on the next run so pending IDs are
+retried before normal processing.
+
 ### Run the MCP Server
 Start the FastMCP server over stdio (default):
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.14"
+version = "0.26.15"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.14"
+version = "0.26.15"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- retry IMDb IDs via persisted queue
- handle numeric season titles when fetching TMDb episodes

## Why
- avoid losing IMDb metadata when rate-limited
- ensure TMDb episode lookups work for year-named seasons

## Affects
- loader, tests, docs

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- updated README with IMDb queue notes

------
https://chatgpt.com/codex/tasks/task_e_68c659dcc1948328a202e8db39d7e781