### PR TITLE
feat: map Plex season numbers to TMDb

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@
   avoid unnecessary model downloads when reranking is disabled or unavailable.
 - Media payload and artwork caching centralized in `MediaCache` attached to
   `PlexServer` to streamline cache management and testing.
+- Plex episodes with year-based seasons are mapped to the correct TMDb season
+  numbers via a helper that matches season names or air-date years to ensure
+  accurate episode lookups.
 
 ## User Queries
 The project should handle natural-language searches and recommendations such as:

--- a/mcp_plex/types.py
+++ b/mcp_plex/types.py
@@ -50,6 +50,12 @@ class TMDBGenre(BaseModel):
     name: str
 
 
+class TMDBSeason(BaseModel):
+    season_number: int
+    name: str
+    air_date: Optional[str] = None
+
+
 class TMDBMovie(BaseModel):
     id: int
     title: str
@@ -77,6 +83,7 @@ class TMDBShow(BaseModel):
     first_air_date: Optional[str] = None
     last_air_date: Optional[str] = None
     genres: List[TMDBGenre] = Field(default_factory=list)
+    seasons: List[TMDBSeason] = Field(default_factory=list)
     poster_path: Optional[str] = None
     backdrop_path: Optional[str] = None
     tagline: Optional[str] = None
@@ -153,6 +160,7 @@ __all__ = [
     "IMDbName",
     "TMDBGenre",
     "TMDBMovie",
+    "TMDBSeason",
     "TMDBShow",
     "TMDBEpisode",
     "TMDBItem",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.15"
+version = "0.26.17"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_loader_unit.py
+++ b/tests/test_loader_unit.py
@@ -18,7 +18,9 @@ from mcp_plex.loader import (
     _load_imdb_retry_queue,
     _persist_imdb_retry_queue,
     _process_imdb_retry_queue,
+    resolve_tmdb_season_number,
 )
+from mcp_plex.types import TMDBSeason, TMDBShow
 
 
 def test_extract_external_ids():
@@ -240,3 +242,23 @@ def test_imdb_retry_queue_persists_and_retries(tmp_path, monkeypatch):
     asyncio.run(second_run())
     assert json.loads(queue_path.read_text()) == []
     assert loader._imdb_cache.get("tt1") is not None
+
+
+def test_resolve_tmdb_season_number_matches_name():
+    episode = types.SimpleNamespace(parentIndex=2018, parentTitle="2018")
+    show = TMDBShow(
+        id=1,
+        name="Show",
+        seasons=[TMDBSeason(season_number=14, name="2018")],
+    )
+    assert resolve_tmdb_season_number(show, episode) == 14
+
+
+def test_resolve_tmdb_season_number_matches_air_date():
+    episode = types.SimpleNamespace(parentIndex=2018, parentTitle="Season 2018")
+    show = TMDBShow(
+        id=1,
+        name="Show",
+        seasons=[TMDBSeason(season_number=16, name="Season 16", air_date="2018-01-03")],
+    )
+    assert resolve_tmdb_season_number(show, episode) == 16

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.15"
+version = "0.26.17"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- map Plex episodes to TMDb seasons by name or air date when numeric indices differ
- add `air_date` to `TMDBSeason` to support year-based mapping
- test season-number resolution using TMDb season air dates

## Why
- fixes failed TMDb episode lookups when Plex uses year-indexed seasons like MythBusters

## Affects
- loader season resolution
- TMDb season model
- unit tests

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- updated `AGENTS.md` architecture notes


------
https://chatgpt.com/codex/tasks/task_e_68c65d89ca6483288426656f49d14b9e