### PR TITLE
fix(loader): resolve season using parent year

### DIFF
--- a/mcp_plex/loader.py
+++ b/mcp_plex/loader.py
@@ -219,6 +219,7 @@ def resolve_tmdb_season_number(
     if isinstance(parent_title, str) and parent_title.isdigit():
         return int(parent_title)
     return None
+    return None
 
 
 def _extract_external_ids(item: PlexPartialObject) -> ExternalIDs:

--- a/mcp_plex/loader.py
+++ b/mcp_plex/loader.py
@@ -219,7 +219,6 @@ def resolve_tmdb_season_number(
     if isinstance(parent_title, str) and parent_title.isdigit():
         return int(parent_title)
     return None
-    return None
 
 
 def _extract_external_ids(item: PlexPartialObject) -> ExternalIDs:

--- a/mcp_plex/loader.py
+++ b/mcp_plex/loader.py
@@ -175,6 +175,9 @@ def resolve_tmdb_season_number(
 
     parent_index = getattr(episode, "parentIndex", None)
     parent_title = getattr(episode, "parentTitle", None)
+    parent_year = getattr(episode, "parentYear", None)
+    if parent_year is None:
+        parent_year = getattr(episode, "year", None)
 
     seasons = getattr(show_tmdb, "seasons", []) if show_tmdb else []
 
@@ -195,7 +198,9 @@ def resolve_tmdb_season_number(
 
     # match by air date year when Plex uses year-based seasons
     year: Optional[int] = None
-    if isinstance(parent_index, int):
+    if isinstance(parent_year, int):
+        year = parent_year
+    elif isinstance(parent_index, int):
         year = parent_index
     elif title_norm and title_norm.isdigit():
         year = int(title_norm)
@@ -207,7 +212,9 @@ def resolve_tmdb_season_number(
                 if int(air[:4]) == year:
                     return season.season_number
 
-    if parent_index is not None:
+    if isinstance(parent_index, int):
+        return parent_index
+    if isinstance(parent_index, str) and parent_index.isdigit():
         return int(parent_index)
     if isinstance(parent_title, str) and parent_title.isdigit():
         return int(parent_title)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.17"
+version = "0.26.18"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_loader_unit.py
+++ b/tests/test_loader_unit.py
@@ -262,3 +262,17 @@ def test_resolve_tmdb_season_number_matches_air_date():
         seasons=[TMDBSeason(season_number=16, name="Season 16", air_date="2018-01-03")],
     )
     assert resolve_tmdb_season_number(show, episode) == 16
+
+
+def test_resolve_tmdb_season_number_parent_year_fallback():
+    episode = types.SimpleNamespace(
+        parentIndex="Special",
+        parentTitle="Special",
+        parentYear=2018,
+    )
+    show = TMDBShow(
+        id=1,
+        name="Show",
+        seasons=[TMDBSeason(season_number=5, name="Season 5", air_date="2018-06-01")],
+    )
+    assert resolve_tmdb_season_number(show, episode) == 5

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.17"
+version = "0.26.18"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- incorporate parent year from Plex episodes when mapping to TMDb seasons
- add regression test for parent year resolution
- bump version to 0.26.18

## Testing
- `uv run ruff check .`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c66139b7108328b5487081cc3a50da