### PR TITLE
feat: batch fetch Plex items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@
 - Plex episodes with year-based seasons are mapped to the correct TMDb season
   numbers via a helper that matches season names or air-date years to ensure
   accurate episode lookups.
+- Plex metadata is fetched in batches using `fetchItems` to reduce repeated
+  network calls when loading library items.
 
 ## User Queries
 The project should handle natural-language searches and recommendations such as:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.18"
+version = "0.26.19"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_load_from_plex.py
+++ b/tests/test_load_from_plex.py
@@ -8,53 +8,41 @@ from mcp_plex.types import TMDBShow
 
 
 def test_load_from_plex(monkeypatch):
-    def add_fetch(obj):
-        obj.fetchItem = lambda key: obj
-        return obj
-
-    movie = add_fetch(
-        types.SimpleNamespace(
-            ratingKey="101",
-            guid="plex://movie/101",
-            type="movie",
-            title="Inception",
-            guids=[
-                types.SimpleNamespace(id="imdb://tt1375666"),
-                types.SimpleNamespace(id="tmdb://27205"),
-            ],
-        )
+    movie = types.SimpleNamespace(
+        ratingKey="101",
+        guid="plex://movie/101",
+        type="movie",
+        title="Inception",
+        guids=[
+            types.SimpleNamespace(id="imdb://tt1375666"),
+            types.SimpleNamespace(id="tmdb://27205"),
+        ],
     )
 
-    ep1 = add_fetch(
-        types.SimpleNamespace(
-            ratingKey="102",
-            guid="plex://episode/102",
-            type="episode",
-            title="Pilot",
-            parentIndex=1,
-            index=1,
-            guids=[
-                types.SimpleNamespace(id="imdb://tt0959621"),
-                types.SimpleNamespace(id="tmdb://62085"),
-            ],
-        )
+    ep1 = types.SimpleNamespace(
+        ratingKey="102",
+        guid="plex://episode/102",
+        type="episode",
+        title="Pilot",
+        parentIndex=1,
+        index=1,
+        guids=[
+            types.SimpleNamespace(id="imdb://tt0959621"),
+            types.SimpleNamespace(id="tmdb://62085"),
+        ],
     )
-    ep2 = add_fetch(
-        types.SimpleNamespace(
-            ratingKey="103",
-            guid="plex://episode/103",
-            type="episode",
-            title="Cat's in the Bag...",
-            guids=[types.SimpleNamespace(id="imdb://tt0959622")],
-        )
+    ep2 = types.SimpleNamespace(
+        ratingKey="103",
+        guid="plex://episode/103",
+        type="episode",
+        title="Cat's in the Bag...",
+        guids=[types.SimpleNamespace(id="imdb://tt0959622")],
     )
 
-    show = add_fetch(
-        types.SimpleNamespace(
-            ratingKey="201",
-            guids=[types.SimpleNamespace(id="tmdb://1396")],
-            episodes=lambda: [ep1, ep2],
-        )
+    show = types.SimpleNamespace(
+        ratingKey="201",
+        guids=[types.SimpleNamespace(id="tmdb://1396")],
+        episodes=lambda: [ep1, ep2],
     )
 
     movie_section = types.SimpleNamespace(all=lambda: [movie])
@@ -62,7 +50,13 @@ def test_load_from_plex(monkeypatch):
     library = types.SimpleNamespace(
         section=lambda name: movie_section if name == "Movies" else show_section
     )
-    server = types.SimpleNamespace(library=library)
+
+    items = {101: movie, 102: ep1, 103: ep2, 201: show}
+
+    def fetchItems(keys):
+        return [items[int(k)] for k in keys]
+
+    server = types.SimpleNamespace(library=library, fetchItems=fetchItems)
 
     async def handler(request):
         url = str(request.url)

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.18"
+version = "0.26.19"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- batch-retrieve Plex movies, shows, and episodes with `fetchItems`
- document batch fetching in AGENTS guidelines

## Why
- reduce repetitive metadata lookups and network calls

## Affects
- `loader._load_from_plex`
- test expectations and project docs

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- updated `AGENTS.md`

------
https://chatgpt.com/codex/tasks/task_e_68c665c8cef0832895b1ccc7a9e8fe3b