### PR TITLE
feat(loader): batch imdb requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@
   accurate episode lookups.
 - Plex metadata is fetched in batches using `fetchItems` to reduce repeated
   network calls when loading library items.
+- IMDb metadata is fetched via `titles:batchGet` to minimize repeated API calls.
 
 ## User Queries
 The project should handle natural-language searches and recommendations such as:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.19"
+version = "0.26.21"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_load_from_plex.py
+++ b/tests/test_load_from_plex.py
@@ -62,33 +62,34 @@ def test_load_from_plex(monkeypatch):
         url = str(request.url)
         if "themoviedb.org" in url:
             assert request.headers.get("Authorization") == "Bearer key"
-        if "tt1375666" in url:
-            return httpx.Response(
-                200,
-                json={
-                    "id": "tt1375666",
-                    "type": "movie",
-                    "primaryTitle": "Inception",
-                },
-            )
-        if "tt0959621" in url:
-            return httpx.Response(
-                200,
-                json={
-                    "id": "tt0959621",
-                    "type": "episode",
-                    "primaryTitle": "Pilot",
-                },
-            )
-        if "tt0959622" in url:
-            return httpx.Response(
-                200,
-                json={
-                    "id": "tt0959622",
-                    "type": "episode",
-                    "primaryTitle": "Cat's in the Bag...",
-                },
-            )
+        if "titles:batchGet" in url:
+            ids = request.url.params.get_list("titleIds")
+            titles = []
+            if "tt1375666" in ids:
+                titles.append(
+                    {
+                        "id": "tt1375666",
+                        "type": "movie",
+                        "primaryTitle": "Inception",
+                    }
+                )
+            if "tt0959621" in ids:
+                titles.append(
+                    {
+                        "id": "tt0959621",
+                        "type": "episode",
+                        "primaryTitle": "Pilot",
+                    }
+                )
+            if "tt0959622" in ids:
+                titles.append(
+                    {
+                        "id": "tt0959622",
+                        "type": "episode",
+                        "primaryTitle": "Cat's in the Bag...",
+                    }
+                )
+            return httpx.Response(200, json={"titles": titles})
         if "/movie/27205" in url:
             return httpx.Response(200, json={"id": 27205, "title": "Inception"})
         if "/tv/1396/season/1/episode/1" in url:

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.19"
+version = "0.26.21"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- batch IMDb metadata requests using `titles:batchGet`
- test batched IMDb fetching
- bump version to 0.26.21

## Why
- reduce repeated IMDb API calls during load

## Affects
- `mcp_plex/loader.py`
- `tests/test_load_from_plex.py`
- `tests/test_loader_unit.py`
- `AGENTS.md`
- `pyproject.toml`
- `uv.lock`

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68c66a1efd5c83288197ab2d57a50747