### PR TITLE
feat: batch Qdrant upserts and handle HTTP errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@
 - IMDb metadata is fetched via `titles:batchGet` to minimize repeated API calls.
 - The `titles:batchGet` endpoint accepts at most five IDs, so IMDb lookups are
   split into batches of five.
+- Qdrant upserts are batched and network errors are logged so large loads can
+  proceed even when individual batches fail.
 
 ## User Queries
 The project should handle natural-language searches and recommendations such as:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.24"
+version = "0.26.25"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.24"
+version = "0.26.25"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- add HTTP error handling to IMDb/TMDb lookups
- batch Qdrant upserts with logging
- test upsert batching and HTTP failure paths

## Why
- large media loads previously failed on a single network error
- batching ensures progress even when a request fails

## Affects
- loader
- tests

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- added architecture note in AGENTS.md

------
https://chatgpt.com/codex/tasks/task_e_68c69412e424832897f8f440cc3a2aeb