### PR TITLE
Ensure FastMCP lifespan uses async context manager

### DIFF
--- a/mcp_plex/server.py
+++ b/mcp_plex/server.py
@@ -5,6 +5,7 @@ import argparse
 import asyncio
 import inspect
 import json
+from contextlib import asynccontextmanager
 from typing import Annotated, Any, Callable
 
 from fastapi import FastAPI
@@ -55,9 +56,12 @@ class PlexServer(FastMCP):
             https=self.settings.qdrant_https,
         )
 
+        @asynccontextmanager
         async def _lifespan(app: FastMCP):  # noqa: ARG001
-            yield
-            await self.close()
+            try:
+                yield
+            finally:
+                await self.close()
 
         super().__init__(lifespan=_lifespan)
         self._reranker: CrossEncoder | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.25"
+version = "0.26.26"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -204,3 +204,12 @@ def test_rest_endpoints(monkeypatch):
 
         resp = client.get("/rest")
         assert resp.status_code == 200
+
+
+def test_server_lifespan_context(monkeypatch):
+    with _load_server(monkeypatch) as module:
+        async def _lifespan() -> None:
+            async with module.server._mcp_server.lifespan(module.server):
+                pass
+
+        asyncio.run(_lifespan())

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.25"
+version = "0.26.26"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- wrap `PlexServer`'s FastMCP lifespan hook in an `asynccontextmanager` so cleanup runs under HTTP transports
- add a regression test that exercises the low-level server lifespan to guard against regressions
- bump the package version to 0.26.26 and refresh `uv.lock`

## Why
- SSE connections were crashing because FastMCP attempted to enter a plain async generator instead of an async context manager

## Affects
- FastMCP server lifecycle handling and the test suite

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d27e285d44832880c41fef310052b2