### PR TITLE
docs: clarify uv usage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,8 @@ The project should handle natural-language searches and recommendations such as:
 - "Suggest a movie from the 90's with Glenn Close"
 
 ## Dependency Management
-- Use [uv](https://github.com/astral-sh/uv) for all Python dependency management and command execution.
+- Use [uv](https://github.com/astral-sh/uv) for all Python dependency management and command execution; do not fall back to `pip`, `poetry`, or other tools.
+- When inspecting installed packages, look inside the active uv-managed virtual environment (e.g., `.venv/`) rather than the system Python directories.
 - Install project and development dependencies with:
   ```bash
   uv sync --extra dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.30"
+version = "0.26.31"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.30"
+version = "0.26.31"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- tighten the dependency management guidance to explicitly require uv and forbid other tooling
- direct contributors to inspect installed packages within the uv-managed virtual environment
- bump the project version metadata

## Why
- document the preferred workflow so future updates remain consistent with the existing toolchain
- ensure package inspections focus on the correct environment rather than the system interpreter

## Affects
- contributor documentation in `AGENTS.md`
- project version recorded in `pyproject.toml` and `uv.lock`

## Testing
- Not run (documentation-only change)

## Documentation
- Updated `AGENTS.md` with the new guidance

------
https://chatgpt.com/codex/tasks/task_e_68db963434c48328b358e65198d36298