### PR TITLE
fix: adjust docker build dependency sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/root/.local/bin:$PATH"
 
 WORKDIR /app
-COPY docker/pyproject.deps.toml uv.lock ./
-RUN uv sync --no-dev --frozen --manifest-path pyproject.deps.toml
+COPY docker/pyproject.deps.toml ./pyproject.toml
+COPY uv.lock ./
+RUN uv sync --no-dev --frozen && mv pyproject.toml pyproject.deps.toml
 
 COPY . .
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
## Summary
- ensure the Docker build copies the dependency manifest as pyproject.toml before syncing
- restore the manifest filename after uv sync so subsequent steps still use pyproject.deps.toml

## Testing
- not run (Dockerfile change only)


------
https://chatgpt.com/codex/tasks/task_e_68db98babfcc832884cca4a98932ccb6