### PR TITLE
chore: bump version to 0.26.32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.31"
+version = "0.26.32"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.31"
+version = "0.26.32"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- bump the project version to 0.26.32.
- refresh the uv lockfile to match the new version.

## Why
- keep the published version metadata in sync with the latest changes.

## Affects
- packaging metadata in `pyproject.toml` and `uv.lock`.

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- not applicable.


------
https://chatgpt.com/codex/tasks/task_e_68db99c6f1b08328bd61c514a7403e04