### PR TITLE
Fix Docker build by declaring project version

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,5 +1,6 @@
 [project]
 name = "mcp-plex"
+version = "0.26.33"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.32"
+version = "0.26.33"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.32"
+version = "0.26.33"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- declare the project version in `docker/pyproject.deps.toml` so `uv sync` can parse it
- bump the package version and lockfile to 0.26.33 to keep metadata consistent

## Why
- the Docker build fails because the dependency-only `pyproject.toml` lacked a `project.version`, which `uv sync` requires when using the `[project]` table

## Affects
- Docker build dependency resolution and package metadata

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- none


------
https://chatgpt.com/codex/tasks/task_e_68db9bd4458c8328b9b22b5017b0f3df