### PR TITLE
Fix REST OpenAPI request body definitions

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.34"
+version = "0.26.35"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.34"
+version = "0.26.35"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.34"
+version = "0.26.35"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- generate Pydantic request models for REST tool and prompt endpoints when building the OpenAPI schema
- update the REST endpoint tests to assert that POST operations expose JSON bodies instead of query parameters
- bump the project version to 0.26.35 and mirror the change in docker dependencies

## Why
- the Swagger UI was incorrectly documenting POST endpoints such as `/rest/search-media` with query parameters, leading to broken example requests

## Affects
- REST OpenAPI schema generation and related tests

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- No additional documentation changes were required beyond the corrected OpenAPI schema

------
https://chatgpt.com/codex/tasks/task_e_68dba2402c7c8328bf224b83d75432f8