### PR TITLE
fix: index show metadata fields

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.35"
+version = "0.26.38"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/types.py
+++ b/mcp_plex/types.py
@@ -127,6 +127,10 @@ class PlexItem(BaseModel):
     guid: str
     type: Literal["movie", "episode"]
     title: str
+    show_title: Optional[str] = None
+    season_title: Optional[str] = None
+    season_number: Optional[int] = None
+    episode_number: Optional[int] = None
     summary: Optional[str] = None
     year: Optional[int] = None
     added_at: Optional[datetime] = None
@@ -138,6 +142,8 @@ class PlexItem(BaseModel):
     directors: List[PlexPerson] = Field(default_factory=list)
     writers: List[PlexPerson] = Field(default_factory=list)
     actors: List[PlexPerson] = Field(default_factory=list)
+    genres: List[str] = Field(default_factory=list)
+    collections: List[str] = Field(default_factory=list)
 
 
 class AggregatedItem(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.35"
+version = "0.26.38"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -82,6 +82,11 @@ def test_server_tools(monkeypatch):
         res = asyncio.run(server.get_media.fn(identifier="tt8367814"))
         assert res and res[0]["plex"]["rating_key"] == movie_id
 
+        episode = asyncio.run(server.get_media.fn(identifier="61960"))
+        assert episode and episode[0]["show_title"] == "Alien: Earth"
+        assert episode[0]["season_number"] == 1
+        assert episode[0]["episode_number"] == 4
+
         poster = asyncio.run(server.media_poster.fn(identifier=movie_id))
         assert isinstance(poster, str) and "thumb" in poster
         assert server.server.cache.get_poster(movie_id) == poster
@@ -104,6 +109,30 @@ def test_server_tools(monkeypatch):
             server.search_media.fn(query="Matthew McConaughey crime movie", limit=1)
         )
         assert res and res[0]["plex"]["title"] == "The Gentlemen"
+
+        structured = asyncio.run(
+            server.query_media.fn(
+                dense_query="crime comedy",
+                title="Gentlemen",
+                type="movie",
+                directors=["Guy Ritchie"],
+                limit=1,
+            )
+        )
+        assert structured and structured[0]["plex"]["title"] == "The Gentlemen"
+        assert "directors" in structured[0]
+
+        episode_structured = asyncio.run(
+            server.query_media.fn(
+                type="episode",
+                show_title="Alien: Earth",
+                season_number=1,
+                episode_number=4,
+                limit=1,
+            )
+        )
+        assert episode_structured and episode_structured[0]["plex"]["rating_key"] == "61960"
+        assert episode_structured[0]["show_title"] == "Alien: Earth"
 
         rec = asyncio.run(server.recommend_media.fn(identifier=movie_id, limit=1))
         assert rec and rec[0]["plex"]["rating_key"] == "61960"
@@ -129,6 +158,9 @@ def test_new_media_tools(monkeypatch):
         shows = asyncio.run(server.new_shows.fn(limit=1))
         assert shows and shows[0]["plex"]["type"] == "episode"
         assert shows[0]["plex"]["added_at"] is not None
+        assert shows[0]["show_title"] == "Alien: Earth"
+        assert shows[0]["season_number"] == 1
+        assert shows[0]["episode_number"] == 4
 
 
 def test_actor_movies(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.35"
+version = "0.26.38"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- add Qdrant payload indices for show titles, season numbers, and episode numbers and expose them via query-media filters
- capture index creation in the loader integration test and assert episode filtering works through the server tool suite

## Why
- ensure episode context can be filtered efficiently during retrieval

## Affects
- loader Qdrant setup, structured query handling, and associated tests

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- not needed

------
https://chatgpt.com/codex/tasks/task_e_68e0cc7b6dec8328b789c6df0c622ef7