### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_load_from_plex.py
+++ b/tests/test_load_from_plex.py
@@ -2,7 +2,7 @@ import asyncio
 import types
 
 import httpx
-
+from urllib.parse import urlparse
 from mcp_plex import loader
 from mcp_plex.types import TMDBShow
 
@@ -60,7 +60,8 @@ def test_load_from_plex(monkeypatch):
 
     async def handler(request):
         url = str(request.url)
-        if "themoviedb.org" in url:
+        hostname = urlparse(url).hostname
+        if hostname and hostname.endswith("themoviedb.org"):
             assert request.headers.get("Authorization") == "Bearer key"
         if "titles:batchGet" in url:
             ids = request.url.params.get_list("titleIds")


### PR DESCRIPTION
Potential fix for [https://github.com/constructorfleet/mcp-plex/security/code-scanning/4](https://github.com/constructorfleet/mcp-plex/security/code-scanning/4)

The correct way to check if a request is being made to "themoviedb.org" is to parse the URL and inspect its `hostname` component (which can be extracted via urllib.parse in Python). Replace the substring match `if "themoviedb.org" in url:` with parsing the URL (with urllib.parse.urlparse), and then checking that `hostname` is equal to "themoviedb.org" or a subdomain thereof (possibly endswith ".themoviedb.org"). For the context of this test code, checking `hostname and hostname.endswith("themoviedb.org")` suffices. We need to import `urlparse` from `urllib.parse`, and use it in the handler function at line 61. Only the handler function and the import statement need to be modified in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
