### PR TITLE
Add Plex playback tool with configurable player aliases

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.45"
+version = "0.26.46"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.44"
+version = "0.26.45"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/config.py
+++ b/mcp_plex/config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from pydantic import Field
+import json
+
+from pydantic import AnyHttpUrl, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -35,5 +37,24 @@ class Settings(BaseSettings):
     )
     cache_size: int = Field(default=128, validation_alias="CACHE_SIZE")
     use_reranker: bool = Field(default=True, validation_alias="USE_RERANKER")
+    plex_url: AnyHttpUrl | None = Field(default=None, validation_alias="PLEX_URL")
+    plex_token: str | None = Field(default=None, validation_alias="PLEX_TOKEN")
+    plex_player_aliases: dict[str, str] = Field(
+        default_factory=dict, validation_alias="PLEX_PLAYER_ALIASES"
+    )
+
+    @field_validator("plex_player_aliases", mode="before")
+    @classmethod
+    def _parse_aliases(cls, value: object) -> dict[str, str]:
+        if value in (None, ""):
+            return {}
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except json.JSONDecodeError as exc:
+                raise ValueError("PLEX_PLAYER_ALIASES must be valid JSON") from exc
+        if isinstance(value, dict):
+            return {str(k): str(v) for k, v in value.items()}
+        raise TypeError("PLEX_PLAYER_ALIASES must be a mapping or JSON object")
 
     model_config = SettingsConfigDict(case_sensitive=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.44"
+version = "0.26.45"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.45"
+version = "0.26.46"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 import pytest
 from pydantic import ValidationError
+from pydantic_settings import SettingsError
 
 from mcp_plex.config import Settings
 
@@ -13,4 +14,22 @@ def test_settings_env_override(monkeypatch):
 def test_settings_invalid_cache_size(monkeypatch):
     monkeypatch.setenv("CACHE_SIZE", "notint")
     with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_settings_player_aliases(monkeypatch):
+    monkeypatch.setenv(
+        "PLEX_PLAYER_ALIASES",
+        "{\"machine-1\": \"Living Room\", \"client-2\": \"Bedroom\"}",
+    )
+    settings = Settings()
+    assert settings.plex_player_aliases == {
+        "machine-1": "Living Room",
+        "client-2": "Bedroom",
+    }
+
+
+def test_settings_invalid_aliases(monkeypatch):
+    monkeypatch.setenv("PLEX_PLAYER_ALIASES", "not-json")
+    with pytest.raises(SettingsError):
         Settings()

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.44"
+version = "0.26.45"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.45"
+version = "0.26.46"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- add Plex playback helpers and a `play-media` FastMCP tool that targets Plex clients by friendly name, machine id, or client id
- extend configuration to accept Plex connection settings and JSON friendly-name mappings for clients
- cover the new behaviour with configuration parsing tests and mocked playback integration tests
- bump the project version metadata

## Why
- allow users to trigger playback for specific Plex players while supporting custom aliases for devices that report duplicate names

## Affects
- Plex server tooling, configuration parsing, automated tests, and package metadata

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- Not needed

------
https://chatgpt.com/codex/tasks/task_e_68e0ff3a67148328b2baebe27bcc8041