### PR TITLE
Resolve pytest warnings for invalid JSON tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ The project should handle natural-language searches and recommendations such as:
 
 ## Checks
 - Run linting with `uv run ruff check .`.
-- Run the test suite with `uv run pytest` and ensure it passes before committing.
+- Run the test suite with `uv run pytest`, ensure it passes, and address any warnings emitted by the run before committing.
 
 ## Testing Practices
 - Use realistic (or as realistic as possible) data in tests; avoid meaningless placeholder values.

--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.46"
+version = "0.26.47"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.46"
+version = "0.26.47"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -434,7 +434,7 @@ def test_rest_query_media_invalid_json(monkeypatch):
         client = TestClient(module.server.http_app())
         response = client.post(
             "/rest/query-media",
-            data="not json",
+            content="not json",
             headers={"content-type": "application/json"},
         )
         assert response.status_code == 200
@@ -452,7 +452,7 @@ def test_rest_prompt_invalid_json(monkeypatch):
         client = TestClient(module.server.http_app())
         response = client.post(
             "/rest/prompt/media-info",
-            data="not json",
+            content="not json",
             headers={"content-type": "application/json"},
         )
         assert response.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.46"
+version = "0.26.47"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- update invalid JSON REST tests to use `content` so httpx no longer emits deprecation warnings
- document in AGENTS.md that pytest warnings must be addressed and bump the package version metadata

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e105a8abe48328b4606e7b8fe709a5