### PR TITLE
Add fuzzy alias matching for Plex players

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.47"
+version = "0.26.48"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.48"
+version = "0.26.49"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/config.py
+++ b/mcp_plex/config.py
@@ -39,13 +39,13 @@ class Settings(BaseSettings):
     use_reranker: bool = Field(default=True, validation_alias="USE_RERANKER")
     plex_url: AnyHttpUrl | None = Field(default=None, validation_alias="PLEX_URL")
     plex_token: str | None = Field(default=None, validation_alias="PLEX_TOKEN")
-    plex_player_aliases: dict[str, str] = Field(
+    plex_player_aliases: dict[str, list[str]] = Field(
         default_factory=dict, validation_alias="PLEX_PLAYER_ALIASES"
     )
 
     @field_validator("plex_player_aliases", mode="before")
     @classmethod
-    def _parse_aliases(cls, value: object) -> dict[str, str]:
+    def _parse_aliases(cls, value: object) -> dict[str, list[str]]:
         if value in (None, ""):
             return {}
         if isinstance(value, str):
@@ -54,7 +54,25 @@ class Settings(BaseSettings):
             except json.JSONDecodeError as exc:
                 raise ValueError("PLEX_PLAYER_ALIASES must be valid JSON") from exc
         if isinstance(value, dict):
-            return {str(k): str(v) for k, v in value.items()}
+            parsed: dict[str, list[str]] = {}
+            for raw_key, raw_aliases in value.items():
+                key = str(raw_key)
+                if isinstance(raw_aliases, str):
+                    aliases = [raw_aliases]
+                elif isinstance(raw_aliases, (list, tuple, set)):
+                    aliases = [str(alias) for alias in raw_aliases]
+                else:
+                    raise TypeError(
+                        "PLEX_PLAYER_ALIASES values must be strings or iterables of strings"
+                    )
+                normalized = []
+                for alias in aliases:
+                    alias_str = str(alias).strip()
+                    if alias_str and alias_str not in normalized:
+                        normalized.append(alias_str)
+                if normalized:
+                    parsed[key] = normalized
+            return parsed
         raise TypeError("PLEX_PLAYER_ALIASES must be a mapping or JSON object")
 
     model_config = SettingsConfigDict(case_sensitive=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.48"
+version = "0.26.49"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.47"
+version = "0.26.48"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,12 +20,15 @@ def test_settings_invalid_cache_size(monkeypatch):
 def test_settings_player_aliases(monkeypatch):
     monkeypatch.setenv(
         "PLEX_PLAYER_ALIASES",
-        "{\"machine-1\": \"Living Room\", \"client-2\": \"Bedroom\"}",
+        (
+            "{\"machine-1\": [\"Living Room TV\", \"Living Room\"],"
+            " \"client-2\": \"Bedroom\"}"
+        ),
     )
     settings = Settings()
     assert settings.plex_player_aliases == {
-        "machine-1": "Living Room",
-        "client-2": "Bedroom",
+        "machine-1": ["Living Room TV", "Living Room"],
+        "client-2": ["Bedroom"],
     }
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -334,6 +334,15 @@ def test_match_player_unknown_raises():
         server_module._match_player("Kitchen", players)
 
 
+def test_match_player_whitespace_query_preserves_original_input():
+    query = "   "
+
+    with pytest.raises(ValueError) as exc:
+        server_module._match_player(query, [])
+
+    assert str(exc.value) == "Player '   ' not found"
+
+
 def test_reranker_import_failure(monkeypatch):
     monkeypatch.setenv("USE_RERANKER", "1")
     orig_import = builtins.__import__

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.47"
+version = "0.26.48"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.48"
+version = "0.26.49"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- add rapidfuzz-backed fuzzy matching to Plex player selection and support multiple aliases per identifier
- normalize player alias configuration to accept string or iterable inputs and update tests accordingly
- bump project version to 0.26.48 to reflect the new behavior

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e1081057d48328817372d22b79c40c