### PR TITLE
feat: add Qdrant upsert retry queue

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.52"
+version = "0.26.53"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.52"
+version = "0.26.53"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_loader_logging.py
+++ b/tests/test_loader_logging.py
@@ -75,7 +75,7 @@ def test_run_limits_concurrent_upserts(monkeypatch):
     started = asyncio.Queue()
     release_queue = asyncio.Queue()
 
-    async def fake_upsert(client, collection_name, points):
+    async def fake_upsert(client, collection_name, points, **kwargs):
         concurrency["current"] += 1
         concurrency["max"] = max(concurrency["max"], concurrency["current"])
         await started.put(None)
@@ -113,7 +113,7 @@ def test_run_ensures_collection_before_loading(monkeypatch):
         async for item in orig_iter(sample_dir):
             yield item
 
-    async def fake_upsert(client, collection_name, points):
+    async def fake_upsert(client, collection_name, points, **kwargs):
         return None
 
     monkeypatch.setattr(loader, "_ensure_collection", fake_ensure)

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.52"
+version = "0.26.53"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- add a retry queue for Qdrant batch upserts with exponential backoff handling
- update the loader to schedule retries after normal upsert tasks complete and expose configuration defaults
- extend unit tests to cover the new retry behavior and update monkeypatched helpers, bump the project version metadata

## Why
- Qdrant batch upserts can timeout intermittently, so the loader should automatically retry failed batches instead of dropping them

## Affects
- loader upsert flow, associated unit tests, and project version metadata

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- not updated (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e15b21e5688328a1c2c747787f14b1