### PR TITLE
fix: parallelize loader upserts

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.55"
+version = "0.26.56"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.53"
+version = "0.26.55"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.56"
+version = "0.26.57"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/loader/__init__.py
+++ b/mcp_plex/loader/__init__.py
@@ -9,6 +9,7 @@ import sys
 import warnings
 from collections import deque
 from pathlib import Path
+from types import TracebackType
 from typing import AsyncIterator, Awaitable, Iterable, List, Optional, Sequence, TypeVar
 
 import click
@@ -909,35 +910,46 @@ async def run(
         item_iter = _iter_from_plex(server, tmdb_api_key)
 
     points_buffer: List[models.PointStruct] = []
-    upsert_tasks: set[asyncio.Task[None]] = set()
     qdrant_retry_queue: asyncio.Queue[list[models.PointStruct]] = asyncio.Queue()
     max_concurrent_upserts = _require_positive(
         _qdrant_max_concurrent_upserts, name="max_concurrent_upserts"
     )
+    upsert_queue: asyncio.Queue[List[models.PointStruct] | None] = asyncio.Queue()
+    batches_enqueued = 0
+    worker_error: Exception | None = None
+    worker_error_tb: TracebackType | None = None
 
-    async def _schedule_upsert(batch: List[models.PointStruct]) -> None:
-        logger.info(
-            "Upserting %d points into Qdrant collection %s in batches of %d",
-            len(batch),
-            collection_name,
-            _qdrant_batch_size,
-        )
-        task = asyncio.create_task(
-            _upsert_in_batches(
-                client,
+    async def _upsert_worker() -> None:
+        nonlocal worker_error, worker_error_tb
+        while True:
+            batch = await upsert_queue.get()
+            if batch is None:
+                upsert_queue.task_done()
+                break
+            logger.info(
+                "Upserting %d points into Qdrant collection %s using batches of up to %d",
+                len(batch),
                 collection_name,
-                batch,
-                retry_queue=qdrant_retry_queue,
+                _qdrant_batch_size,
             )
-        )
-        upsert_tasks.add(task)
-        if len(upsert_tasks) >= max_concurrent_upserts:
-            done, _ = await asyncio.wait(
-                upsert_tasks, return_when=asyncio.FIRST_COMPLETED
-            )
-            for finished in done:
-                upsert_tasks.discard(finished)
-                finished.result()
+            try:
+                await _upsert_in_batches(
+                    client,
+                    collection_name,
+                    batch,
+                    retry_queue=qdrant_retry_queue,
+                )
+            except Exception as exc:  # defensive guard
+                if worker_error is None:
+                    worker_error = exc
+                    worker_error_tb = exc.__traceback__
+                logger.exception("Unexpected error upserting batch")
+            finally:
+                upsert_queue.task_done()
+
+    upsert_workers = [
+        asyncio.create_task(_upsert_worker()) for _ in range(max_concurrent_upserts)
+    ]
 
     async for item in item_iter:
         items.append(item)
@@ -1048,19 +1060,30 @@ async def run(
         if len(points_buffer) >= upsert_buffer_size:
             batch = list(points_buffer)
             points_buffer.clear()
-            await _schedule_upsert(batch)
+            batches_enqueued += 1
+            await upsert_queue.put(batch)
 
     logger.info("Loaded %d items", len(items))
 
     if points_buffer:
         batch = list(points_buffer)
         points_buffer.clear()
-        await _schedule_upsert(batch)
+        batches_enqueued += 1
+        await upsert_queue.put(batch)
 
-    if upsert_tasks:
-        await asyncio.gather(*upsert_tasks)
-    else:
-        logger.info("No points to upsert")
+    try:
+        await upsert_queue.join()
+        if batches_enqueued == 0:
+            logger.info("No points to upsert")
+    finally:
+        for _ in range(max_concurrent_upserts):
+            await upsert_queue.put(None)
+        await asyncio.gather(*upsert_workers)
+
+    if worker_error is not None:
+        if worker_error_tb is not None:
+            raise worker_error.with_traceback(worker_error_tb)
+        raise worker_error
 
     await _process_qdrant_retry_queue(client, collection_name, qdrant_retry_queue)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.56"
+version = "0.26.57"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.53"
+version = "0.26.55"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.55"
+version = "0.26.56"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.56"
+version = "0.26.57"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.53"
+version = "0.26.55"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.55"
+version = "0.26.56"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- stream loader Qdrant upserts through bounded background workers so ingestion continues while batches persist and errors bubble up safely
- adjust the loader logging concurrency test to wait deterministically for queued batches
- bump the project version metadata and refresh the uv lockfile

## Why
- the previous scheduling awaited Qdrant batches inline once the concurrency limit was reached, which made point writes effectively synchronous with metadata fetching
- keep the recorded package version consistent across manifests

## Affects
- loader Qdrant upsert pipeline and concurrency-focused tests
- project version metadata

## Testing
- `uv run pytest`
- `uv run ruff check .`

## Documentation
- no documentation changes needed

------
https://chatgpt.com/codex/tasks/task_e_68e177c06d8c83289078fcc110cfccb0