### PR TITLE
docs: adopt architecture decision records

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 - The project is organized into dedicated `loader`, `server`, and `common` packages under `mcp_plex/`.
 - Package-specific architectural notes live alongside the code in `mcp_plex/loader/AGENTS.md`, `mcp_plex/server/AGENTS.md`, and `mcp_plex/common/AGENTS.md`.
 - Update this file when repo-wide conventions or folder-level guidelines change.
+- Review the Architecture Decision Records in `docs/adr/` before implementing changes that affect system design, and document
+  new architectural decisions with an ADR.
 
 ## User Queries
 The project should handle natural-language searches and recommendations such as:

--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.57"
+version = "0.26.58"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/docs/adr/0001-adopt-architecture-decision-records.md
+++ b/docs/adr/0001-adopt-architecture-decision-records.md
@@ -1,0 +1,26 @@
+# ADR 0001: Adopt Architecture Decision Records
+
+## Status
+Accepted
+
+## Context
+The project has grown to include multiple interacting packages and components. Without a shared process for capturing
+design rationale, contributors risk duplicating past discussions or introducing changes that conflict with existing
+architecture decisions.
+
+## Decision
+We will maintain Architecture Decision Records (ADRs) under `docs/adr/`. Each ADR will document the problem being
+addressed, the selected solution, the rationale behind that solution, and any implications for future work. Any change
+that affects application architecture, cross-cutting concerns, or long-lived design choices must reference an ADR.
+
+## Consequences
+- Contributors must review existing ADRs before proposing architectural changes or implementing features that interact
+  with the affected areas.
+- New architectural decisions require a new ADR that follows this template.
+- Pull requests introducing architectural changes must link to the relevant ADR(s) in their description.
+- The AGENTS instructions reference the ADR process so that future agents stay aligned with the documented design.
+
+## Implementation Notes
+- Store ADR files using the naming convention `NNNN-title.md` where `NNNN` is a zero-padded sequence number.
+- Keep ADRs in chronological order and avoid renaming files to preserve history.
+- Use Markdown headings: Status, Context, Decision, Consequences, and Implementation Notes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.57"
+version = "0.26.58"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.57"
+version = "0.26.58"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- establish an Architecture Decision Record (ADR) directory with an initial record adopting the ADR process
- update contributor guidance to require reviewing and extending ADRs for architectural changes
- bump the project version to 0.26.58 to reflect the new documentation process

## Why
- capture architectural decisions so future contributors understand design rationale and avoid conflicting changes

## Affects
- repository-wide contributor workflow expectations
- project metadata versioning

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- added `docs/adr/0001-adopt-architecture-decision-records.md`

------
https://chatgpt.com/codex/tasks/task_e_68e24a490f8c8328b28eeb6b2635d77b