### PR TITLE
feat(loader): scaffold pipeline package

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.60"
+version = "0.26.61"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/loader/pipeline/__init__.py
+++ b/mcp_plex/loader/pipeline/__init__.py
@@ -1,0 +1,34 @@
+"""Loader pipeline package exports placeholder interfaces for pipeline stages."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ChannelDefinition(Protocol):
+    """Placeholder protocol for defining loader pipeline channels."""
+
+
+class IngestionStage(Protocol):
+    """Placeholder protocol for pipeline ingestion stage implementations."""
+
+
+class EnrichmentStage(Protocol):
+    """Placeholder protocol for pipeline enrichment stage implementations."""
+
+
+class PersistenceStage(Protocol):
+    """Placeholder protocol for pipeline persistence stage implementations."""
+
+
+class PipelineOrchestrator(Protocol):
+    """Placeholder protocol for orchestrating loader pipeline stages."""
+
+
+__all__ = [
+    "ChannelDefinition",
+    "IngestionStage",
+    "EnrichmentStage",
+    "PersistenceStage",
+    "PipelineOrchestrator",
+]

--- a/mcp_plex/loader/pipeline/channels.py
+++ b/mcp_plex/loader/pipeline/channels.py
@@ -1,0 +1,1 @@
+"""Placeholder module for the loader pipeline."""

--- a/mcp_plex/loader/pipeline/enrichment.py
+++ b/mcp_plex/loader/pipeline/enrichment.py
@@ -1,0 +1,1 @@
+"""Placeholder module for the loader pipeline."""

--- a/mcp_plex/loader/pipeline/ingestion.py
+++ b/mcp_plex/loader/pipeline/ingestion.py
@@ -1,0 +1,1 @@
+"""Placeholder module for the loader pipeline."""

--- a/mcp_plex/loader/pipeline/orchestrator.py
+++ b/mcp_plex/loader/pipeline/orchestrator.py
@@ -1,0 +1,1 @@
+"""Placeholder module for the loader pipeline."""

--- a/mcp_plex/loader/pipeline/persistence.py
+++ b/mcp_plex/loader/pipeline/persistence.py
@@ -1,0 +1,1 @@
+"""Placeholder module for the loader pipeline."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.60"
+version = "0.26.61"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.60"
+version = "0.26.61"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- add a new `mcp_plex.loader.pipeline` package with placeholder stage protocols
- bump the project version to 0.26.61 and sync the Docker dependency manifest
- regenerate `uv.lock` to capture the version change

## Why
- scaffold the loader pipeline structure so future work can extend it without modifying the main loader entrypoint

## Affects
- loader package layout and project metadata

## Testing
- `uv run ruff check mcp_plex/loader/pipeline`
- `uv run pytest`

## Documentation
- not needed

------
https://chatgpt.com/codex/tasks/task_e_68e29e6d7e248328b7f8e042d52374d3