### PR TITLE
feat: scaffold ingestion stage skeleton

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.61"
+version = "0.26.62"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/loader/pipeline/ingestion.py
+++ b/mcp_plex/loader/pipeline/ingestion.py
@@ -1,1 +1,80 @@
-"""Placeholder module for the loader pipeline."""
+"""Ingestion stage coordinator for the loader pipeline.
+
+At the moment the module only wires the configuration needed by the real
+implementation.  The heavy lifting will be ported in subsequent commits, but
+having the stage skeleton in place allows other components to depend on the
+interface.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Sequence
+
+from ...common.types import AggregatedItem
+from .channels import IngestQueue
+
+
+class IngestionStage:
+    """Coordinate ingesting items from Plex or bundled sample data."""
+
+    def __init__(
+        self,
+        *,
+        plex_server: object | None,
+        sample_items: Sequence[AggregatedItem] | None,
+        movie_batch_size: int,
+        episode_batch_size: int,
+        sample_batch_size: int,
+        output_queue: IngestQueue,
+        completion_sentinel: object,
+    ) -> None:
+        self._plex_server = plex_server
+        self._sample_items = list(sample_items) if sample_items is not None else None
+        self._movie_batch_size = int(movie_batch_size)
+        self._episode_batch_size = int(episode_batch_size)
+        self._sample_batch_size = int(sample_batch_size)
+        self._output_queue = output_queue
+        self._completion_sentinel = completion_sentinel
+        self._logger = logging.getLogger("mcp_plex.loader.ingestion")
+
+    @property
+    def logger(self) -> logging.Logger:
+        """Logger used by the ingestion stage."""
+
+        return self._logger
+
+    async def run(self) -> None:
+        """Execute the ingestion stage.
+
+        Sample data takes precedence over Plex driven ingestion.  The
+        placeholders invoked here will be replaced as richer implementations are
+        ported from the legacy loader.
+        """
+
+        if self._sample_items is not None:
+            await self._run_sample_ingestion(self._sample_items)
+        else:
+            await self._run_plex_ingestion()
+
+        await self._output_queue.put(None)
+        await self._output_queue.put(self._completion_sentinel)
+
+    async def _run_sample_ingestion(self, items: Sequence[AggregatedItem]) -> None:
+        """Placeholder hook for the sample ingestion flow."""
+
+        item_count = len(items)
+        self._logger.info(
+            "Sample ingestion has not been ported yet; %d items queued for later.",
+            item_count,
+        )
+        await asyncio.sleep(0)
+
+    async def _run_plex_ingestion(self) -> None:
+        """Placeholder hook for Plex-backed ingestion."""
+
+        if self._plex_server is None:
+            self._logger.warning("Plex server unavailable; skipping ingestion.")
+        else:
+            self._logger.info("Plex ingestion pending implementation.")
+        await asyncio.sleep(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.61"
+version = "0.26.62"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_ingestion_stage.py
+++ b/tests/test_ingestion_stage.py
@@ -1,0 +1,63 @@
+import asyncio
+
+from mcp_plex.common.types import AggregatedItem, PlexItem
+from mcp_plex.loader.pipeline.channels import INGEST_DONE
+from mcp_plex.loader.pipeline.ingestion import IngestionStage
+
+
+def _make_aggregated_item(rating_key: str) -> AggregatedItem:
+    return AggregatedItem(
+        plex=PlexItem(
+            rating_key=rating_key,
+            guid=f"plex://{rating_key}",
+            type="movie",
+            title=f"Title {rating_key}",
+        )
+    )
+
+
+def test_ingestion_stage_logger_name() -> None:
+    async def scenario() -> str:
+        queue: asyncio.Queue = asyncio.Queue()
+        stage = IngestionStage(
+            plex_server=object(),
+            sample_items=None,
+            movie_batch_size=50,
+            episode_batch_size=25,
+            sample_batch_size=10,
+            output_queue=queue,
+            completion_sentinel=INGEST_DONE,
+        )
+        return stage.logger.name
+
+    logger_name = asyncio.run(scenario())
+    assert logger_name == "mcp_plex.loader.ingestion"
+
+
+def test_ingestion_stage_emits_completion_sentinels() -> None:
+    sentinel = object()
+
+    async def scenario() -> tuple[object | None, object | None, bool]:
+        queue: asyncio.Queue = asyncio.Queue()
+        sample_items = [_make_aggregated_item("1"), _make_aggregated_item("2")]
+        stage = IngestionStage(
+            plex_server=None,
+            sample_items=sample_items,
+            movie_batch_size=1,
+            episode_batch_size=1,
+            sample_batch_size=1,
+            output_queue=queue,
+            completion_sentinel=sentinel,
+        )
+
+        await stage.run()
+
+        first = await queue.get()
+        second = await queue.get()
+        return first, second, queue.empty()
+
+    first, second, empty = asyncio.run(scenario())
+
+    assert first is None
+    assert second is sentinel
+    assert empty is True

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.61"
+version = "0.26.62"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- implement an ingestion stage skeleton with configuration, logger wiring, and placeholder execution paths
- add unit tests covering logger instantiation and completion sentinel behavior
- bump the project version to 0.26.62 across manifests and lock file

## Why
- establish the ingestion pipeline interface so downstream stages can integrate while legacy logic is ported
- ensure the temporary behavior is covered by unit tests and release metadata stays consistent

## Affects
- loader pipeline ingestion module
- versioned project metadata and lock file
- new ingestion stage unit tests

## Testing
- `uv run pytest tests/test_ingestion_stage.py`

## Documentation
- not needed

------
https://chatgpt.com/codex/tasks/task_e_68e2aade4e3c8328acbaa7434f047451