### PR TITLE
feat: batch sample ingestion stage

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.62"
+version = "0.26.63"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.62"
+version = "0.26.63"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_ingestion_stage.py
+++ b/tests/test_ingestion_stage.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from mcp_plex.common.types import AggregatedItem, PlexItem
-from mcp_plex.loader.pipeline.channels import INGEST_DONE
+from mcp_plex.loader.pipeline.channels import INGEST_DONE, SampleBatch
 from mcp_plex.loader.pipeline.ingestion import IngestionStage
 
 
@@ -34,12 +34,84 @@ def test_ingestion_stage_logger_name() -> None:
     assert logger_name == "mcp_plex.loader.ingestion"
 
 
-def test_ingestion_stage_emits_completion_sentinels() -> None:
+def test_ingestion_stage_sample_empty_batches() -> None:
     sentinel = object()
 
-    async def scenario() -> tuple[object | None, object | None, bool]:
+    async def scenario() -> tuple[object | None, object | None, bool, int, int]:
         queue: asyncio.Queue = asyncio.Queue()
-        sample_items = [_make_aggregated_item("1"), _make_aggregated_item("2")]
+        stage = IngestionStage(
+            plex_server=None,
+            sample_items=[],
+            movie_batch_size=1,
+            episode_batch_size=1,
+            sample_batch_size=2,
+            output_queue=queue,
+            completion_sentinel=sentinel,
+        )
+
+        await stage.run()
+
+        first = await queue.get()
+        second = await queue.get()
+        return first, second, queue.empty(), stage.items_ingested, stage.batches_ingested
+
+    first, second, empty, items_ingested, batches_ingested = asyncio.run(scenario())
+
+    assert first is None
+    assert second is sentinel
+    assert empty is True
+    assert items_ingested == 0
+    assert batches_ingested == 0
+
+
+def test_ingestion_stage_sample_partial_batches() -> None:
+    sentinel = object()
+
+    async def scenario() -> tuple[list[SampleBatch], object | None, object | None, int, int]:
+        queue: asyncio.Queue = asyncio.Queue()
+        sample_items = [
+            _make_aggregated_item("1"),
+            _make_aggregated_item("2"),
+            _make_aggregated_item("3"),
+        ]
+        stage = IngestionStage(
+            plex_server=None,
+            sample_items=sample_items,
+            movie_batch_size=1,
+            episode_batch_size=1,
+            sample_batch_size=2,
+            output_queue=queue,
+            completion_sentinel=sentinel,
+        )
+
+        await stage.run()
+
+        batches = [await queue.get(), await queue.get()]
+        first_token = await queue.get()
+        second_token = await queue.get()
+        return batches, first_token, second_token, stage.items_ingested, stage.batches_ingested
+
+    batches, first_token, second_token, items_ingested, batches_ingested = asyncio.run(
+        scenario()
+    )
+
+    assert all(isinstance(batch, SampleBatch) for batch in batches)
+    assert [len(batch.items) for batch in batches] == [2, 1]
+    assert first_token is None
+    assert second_token is sentinel
+    assert items_ingested == 3
+    assert batches_ingested == 2
+
+
+def test_ingestion_stage_backpressure_handling() -> None:
+    sentinel = object()
+
+    async def scenario() -> tuple[list[SampleBatch], object | None, object | None, int, int]:
+        queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+        sample_items = [
+            _make_aggregated_item("1"),
+            _make_aggregated_item("2"),
+        ]
         stage = IngestionStage(
             plex_server=None,
             sample_items=sample_items,
@@ -50,14 +122,27 @@ def test_ingestion_stage_emits_completion_sentinels() -> None:
             completion_sentinel=sentinel,
         )
 
-        await stage.run()
+        run_task = asyncio.create_task(stage.run())
+        await asyncio.sleep(0)
+        assert run_task.done() is False
 
-        first = await queue.get()
-        second = await queue.get()
-        return first, second, queue.empty()
+        first_batch = await queue.get()
+        assert isinstance(first_batch, SampleBatch)
+        await asyncio.sleep(0)
 
-    first, second, empty = asyncio.run(scenario())
+        second_batch = await queue.get()
+        first_token = await queue.get()
+        second_token = await queue.get()
 
-    assert first is None
-    assert second is sentinel
-    assert empty is True
+        await run_task
+        return [first_batch, second_batch], first_token, second_token, stage.items_ingested, stage.batches_ingested
+
+    batches, first_token, second_token, items_ingested, batches_ingested = asyncio.run(
+        scenario()
+    )
+
+    assert [len(batch.items) for batch in batches] == [1, 1]
+    assert first_token is None
+    assert second_token is sentinel
+    assert items_ingested == 2
+    assert batches_ingested == 2

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.62"
+version = "0.26.63"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- batch sample-mode ingestion in the pipeline stage and expose observable counters
- add async coverage for empty, partial, and backpressure scenarios in the ingestion stage tests
- bump the package version to 0.26.63 (and docker manifest) to reflect the new behavior

## Why
- moves batching logic from the legacy loader into the pipeline stage so the queue receives sized batches and observability counters
- exercises the new batching and backpressure logic to prevent regressions

## Affects
- loader pipeline ingestion stage and its unit tests
- project version metadata and lockfile

## Testing
- `uv run pytest`

## Documentation
- not needed


------
https://chatgpt.com/codex/tasks/task_e_68e2ad1cc9588328b28e31cae41ec07f