### PR TITLE
feat: port movie enrichment into pipeline stage

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.64"
+version = "0.26.65"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/loader/pipeline/enrichment.py
+++ b/mcp_plex/loader/pipeline/enrichment.py
@@ -1,17 +1,18 @@
 """Enrichment stage coordinator for the loader pipeline.
 
-The real enrichment logic pulls additional metadata from TMDb and IMDb before
-handing the enriched payloads off to the persistence stage.  Only the stage
-scaffolding is implemented for now so other pipeline components can start
-interacting with a consistent interface while the remaining logic is ported in
-follow-up changes.
+Movie metadata enrichment has been ported from the legacy loader and now
+performs TMDb and IMDb lookups before emitting aggregated payloads to the
+persistence queue.  Episode and sample handling remain placeholder hooks while
+the rest of the legacy logic is migrated.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from contextlib import asynccontextmanager
+import inspect
 from typing import Any
 
 from .channels import (
@@ -22,6 +23,16 @@ from .channels import (
     MovieBatch,
     PersistenceQueue,
     SampleBatch,
+    chunk_sequence,
+    require_positive,
+)
+
+from ...common.types import AggregatedItem
+from .. import (
+    _build_plex_item,
+    _extract_external_ids,
+    _fetch_imdb_batch,
+    _fetch_tmdb_movie,
 )
 
 
@@ -45,8 +56,13 @@ class EnrichmentStage:
         self._ingest_queue = ingest_queue
         self._persistence_queue = persistence_queue
         self._imdb_retry_queue = imdb_retry_queue or IMDbRetryQueue()
-        self._movie_batch_size = int(movie_batch_size)
-        self._episode_batch_size = int(episode_batch_size)
+        requested_movie_batch_size = require_positive(
+            int(movie_batch_size), name="movie_batch_size"
+        )
+        self._movie_batch_size = min(requested_movie_batch_size, 100)
+        self._episode_batch_size = require_positive(
+            int(episode_batch_size), name="episode_batch_size"
+        )
         self._logger = logger or logging.getLogger("mcp_plex.loader.enrichment")
 
     @property
@@ -66,35 +82,49 @@ class EnrichmentStage:
 
         while True:
             batch = await self._ingest_queue.get()
+            try:
+                if batch is None:
+                    self._logger.debug(
+                        "Received legacy completion token; ignoring."
+                    )
+                    continue
 
-            if batch is None:
-                self._logger.debug("Received legacy completion token; ignoring.")
-                continue
+                if batch is INGEST_DONE:
+                    self._logger.info(
+                        "Ingestion completed; finishing enrichment stage."
+                    )
+                    break
 
-            if batch is INGEST_DONE:
-                self._logger.info("Ingestion completed; finishing enrichment stage.")
-                break
-
-            if isinstance(batch, MovieBatch):
-                await self._handle_movie_batch(batch)
-            elif isinstance(batch, EpisodeBatch):
-                await self._handle_episode_batch(batch)
-            elif isinstance(batch, SampleBatch):
-                await self._handle_sample_batch(batch)
-            else:  # pragma: no cover - defensive logging for future types
-                self._logger.warning("Received unsupported batch type: %r", batch)
+                if isinstance(batch, MovieBatch):
+                    await self._handle_movie_batch(batch)
+                elif isinstance(batch, EpisodeBatch):
+                    await self._handle_episode_batch(batch)
+                elif isinstance(batch, SampleBatch):
+                    await self._handle_sample_batch(batch)
+                else:  # pragma: no cover - defensive logging for future types
+                    self._logger.warning(
+                        "Received unsupported batch type: %r", batch
+                    )
+            finally:
+                self._ingest_queue.task_done()
 
         await self._persistence_queue.put(None)
 
     async def _handle_movie_batch(self, batch: MovieBatch) -> None:
-        """Placeholder hook for processing Plex movie batches."""
+        """Enrich and forward Plex movie batches to the persistence stage."""
 
-        movie_count = len(batch.movies)
-        self._logger.info(
-            "Movie enrichment has not been ported yet; %d movies queued for later.",
-            movie_count,
-        )
-        await asyncio.sleep(0)
+        movie_chunks = [
+            list(chunk)
+            for chunk in chunk_sequence(batch.movies, self._movie_batch_size)
+            if len(chunk)
+        ]
+        if not movie_chunks:
+            return
+
+        async with self._acquire_http_client() as client:
+            for movies in movie_chunks:
+                aggregated = await self._enrich_movies(client, movies)
+                await self._emit_persistence_batch(aggregated)
 
     async def _handle_episode_batch(self, batch: EpisodeBatch) -> None:
         """Placeholder hook for processing Plex episode batches."""
@@ -107,6 +137,84 @@ class EnrichmentStage:
             show_title,
         )
         await asyncio.sleep(0)
+
+    @asynccontextmanager
+    async def _acquire_http_client(self) -> AsyncIterator[Any]:
+        """Yield an HTTP client from the injected factory."""
+
+        resource = self._http_client_factory()
+        if inspect.isawaitable(resource):
+            resource = await resource
+
+        if hasattr(resource, "__aenter__") and hasattr(resource, "__aexit__"):
+            async with resource as client:
+                yield client
+            return
+
+        if hasattr(resource, "__enter__") and hasattr(resource, "__exit__"):
+            with resource as client:
+                yield client
+            return
+
+        try:
+            yield resource
+        finally:
+            closer = getattr(resource, "aclose", None)
+            if callable(closer):
+                result = closer()
+                if inspect.isawaitable(result):
+                    await result
+                return
+            closer = getattr(resource, "close", None)
+            if callable(closer):
+                result = closer()
+                if inspect.isawaitable(result):
+                    await result
+
+    async def _emit_persistence_batch(
+        self, aggregated: Sequence[AggregatedItem]
+    ) -> None:
+        """Place aggregated items onto the persistence queue."""
+
+        if not aggregated:
+            return
+        await self._persistence_queue.put(list(aggregated))
+
+    async def _enrich_movies(
+        self, client: Any, movies: Sequence[Any]
+    ) -> list[AggregatedItem]:
+        """Fetch external metadata for *movies* and aggregate the results."""
+
+        movie_ids = [_extract_external_ids(movie) for movie in movies]
+        imdb_ids = [ids.imdb for ids in movie_ids if ids.imdb]
+        imdb_map = (
+            await _fetch_imdb_batch(client, imdb_ids) if imdb_ids else {}
+        )
+
+        tmdb_results: list[Any] = []
+        api_key = self._tmdb_api_key
+        if api_key:
+            tmdb_tasks = [
+                _fetch_tmdb_movie(client, ids.tmdb, api_key)
+                for ids in movie_ids
+                if ids.tmdb
+            ]
+            if tmdb_tasks:
+                tmdb_results = await asyncio.gather(*tmdb_tasks)
+        tmdb_iter = iter(tmdb_results)
+
+        aggregated: list[AggregatedItem] = []
+        for movie, ids in zip(movies, movie_ids):
+            tmdb = next(tmdb_iter, None) if ids.tmdb else None
+            imdb = imdb_map.get(ids.imdb) if ids.imdb else None
+            aggregated.append(
+                AggregatedItem(
+                    plex=_build_plex_item(movie),
+                    imdb=imdb,
+                    tmdb=tmdb,
+                )
+            )
+        return aggregated
 
     async def _handle_sample_batch(self, batch: SampleBatch) -> None:
         """Placeholder hook for processing sample data batches."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.64"
+version = "0.26.65"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_enrichment_stage.py
+++ b/tests/test_enrichment_stage.py
@@ -1,26 +1,13 @@
 import asyncio
-import logging
+from typing import Any
 
-from mcp_plex.common.types import AggregatedItem, PlexItem
+from mcp_plex.common.types import AggregatedItem, IMDbTitle, TMDBMovie
 from mcp_plex.loader.pipeline.channels import (
-    EpisodeBatch,
     IMDbRetryQueue,
     INGEST_DONE,
     MovieBatch,
-    SampleBatch,
 )
 from mcp_plex.loader.pipeline.enrichment import EnrichmentStage
-
-
-def _make_aggregated_item(rating_key: str) -> AggregatedItem:
-    return AggregatedItem(
-        plex=PlexItem(
-            rating_key=rating_key,
-            guid=f"plex://{rating_key}",
-            type="movie",
-            title=f"Title {rating_key}",
-        )
-    )
 
 
 def test_enrichment_stage_logger_name() -> None:
@@ -40,48 +27,6 @@ def test_enrichment_stage_logger_name() -> None:
 
     logger_name = asyncio.run(scenario())
     assert logger_name == "mcp_plex.loader.enrichment"
-
-
-def test_enrichment_stage_handles_batches_and_completion(caplog) -> None:
-    caplog.set_level(logging.INFO)
-
-    class FakeShow:
-        def __init__(self, title: str) -> None:
-            self.title = title
-
-    async def scenario() -> tuple[list[str], object | None]:
-        ingest_queue: asyncio.Queue = asyncio.Queue()
-        persistence_queue: asyncio.Queue = asyncio.Queue()
-        stage = EnrichmentStage(
-            http_client_factory=lambda: object(),
-            tmdb_api_key="tmdb",
-            ingest_queue=ingest_queue,
-            persistence_queue=persistence_queue,
-            imdb_retry_queue=IMDbRetryQueue(),
-            movie_batch_size=50,
-            episode_batch_size=25,
-        )
-
-        await ingest_queue.put(MovieBatch(movies=[object(), object()]))
-        await ingest_queue.put(
-            EpisodeBatch(show=FakeShow("Example Show"), episodes=[object()])
-        )
-        await ingest_queue.put(SampleBatch(items=[_make_aggregated_item("1")]))
-        await ingest_queue.put(None)
-        await ingest_queue.put(INGEST_DONE)
-
-        await stage.run()
-
-        completion_token = await persistence_queue.get()
-        messages = [record.getMessage() for record in caplog.records]
-        return messages, completion_token
-
-    messages, completion_token = asyncio.run(scenario())
-
-    assert any("Movie enrichment has not been ported yet" in message for message in messages)
-    assert any("Episode enrichment has not been ported yet" in message for message in messages)
-    assert any("Sample enrichment has not been ported yet" in message for message in messages)
-    assert completion_token is None
 
 
 def test_enrichment_stage_uses_injected_imdb_retry_queue() -> None:
@@ -121,3 +66,191 @@ def test_enrichment_stage_creates_retry_queue_when_missing() -> None:
 
     retry_queue = asyncio.run(scenario())
     assert isinstance(retry_queue, IMDbRetryQueue)
+
+
+class _FakeGuid:
+    def __init__(self, guid: str) -> None:
+        self.id = guid
+
+
+class _FakeMovie:
+    def __init__(
+        self,
+        rating_key: str,
+        *,
+        imdb_id: str | None = None,
+        tmdb_id: str | None = None,
+    ) -> None:
+        self.ratingKey = rating_key
+        self.guid = f"plex://{rating_key}"
+        self.type = "movie"
+        self.title = f"Movie {rating_key}"
+        self.summary = f"Summary {rating_key}"
+        self.year = 2000
+        self.addedAt = None
+        self.guids = []
+        if imdb_id:
+            self.guids.append(_FakeGuid(f"imdb://{imdb_id}"))
+        if tmdb_id:
+            self.guids.append(_FakeGuid(f"tmdb://{tmdb_id}"))
+        self.directors: list[Any] = []
+        self.writers: list[Any] = []
+        self.actors: list[Any] = []
+        self.roles: list[Any] = []
+        self.genres: list[Any] = []
+        self.collections: list[Any] = []
+
+
+class _FakeClient:
+    def __init__(self, log: list[str]) -> None:
+        self._log = log
+
+    async def __aenter__(self) -> "_FakeClient":
+        self._log.append("enter")
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self._log.append("exit")
+
+
+def test_enrichment_stage_enriches_movie_batches_and_emits_chunks(monkeypatch):
+    imdb_requests: list[list[str]] = []
+    tmdb_requests: list[str] = []
+    client_log: list[str] = []
+
+    async def fake_fetch_imdb_batch(client, imdb_ids):
+        imdb_requests.append(list(imdb_ids))
+        return {
+            imdb_id: IMDbTitle(id=imdb_id, type="movie", primaryTitle=f"IMDb {imdb_id}")
+            for imdb_id in imdb_ids
+        }
+
+    async def fake_fetch_tmdb_movie(client, tmdb_id, api_key):
+        tmdb_requests.append(tmdb_id)
+        return TMDBMovie.model_validate({
+            "id": int(tmdb_id),
+            "title": f"TMDb {tmdb_id}",
+        })
+
+    monkeypatch.setattr(
+        EnrichmentStage, "_handle_episode_batch", lambda self, batch: asyncio.sleep(0)
+    )
+    monkeypatch.setattr(
+        EnrichmentStage, "_handle_sample_batch", lambda self, batch: asyncio.sleep(0)
+    )
+    monkeypatch.setattr(
+        "mcp_plex.loader.pipeline.enrichment._fetch_imdb_batch",
+        fake_fetch_imdb_batch,
+    )
+    monkeypatch.setattr(
+        "mcp_plex.loader.pipeline.enrichment._fetch_tmdb_movie",
+        fake_fetch_tmdb_movie,
+    )
+
+    async def scenario() -> list[list[AggregatedItem] | None]:
+        ingest_queue: asyncio.Queue = asyncio.Queue()
+        persistence_queue: asyncio.Queue = asyncio.Queue()
+
+        stage = EnrichmentStage(
+            http_client_factory=lambda: _FakeClient(client_log),
+            tmdb_api_key="token",
+            ingest_queue=ingest_queue,
+            persistence_queue=persistence_queue,
+            imdb_retry_queue=IMDbRetryQueue(),
+            movie_batch_size=2,
+            episode_batch_size=10,
+        )
+
+        movies = [
+            _FakeMovie("1", imdb_id="tt1", tmdb_id="101"),
+            _FakeMovie("2", imdb_id="tt2", tmdb_id="102"),
+            _FakeMovie("3", imdb_id="tt3", tmdb_id="103"),
+        ]
+        await ingest_queue.put(MovieBatch(movies=movies))
+        await ingest_queue.put(INGEST_DONE)
+
+        await stage.run()
+
+        emitted: list[list[AggregatedItem] | None] = []
+        while True:
+            payload = await persistence_queue.get()
+            emitted.append(payload)
+            if payload is None:
+                break
+        return emitted
+
+    emitted_batches = asyncio.run(scenario())
+
+    assert imdb_requests == [["tt1", "tt2"], ["tt3"]]
+    assert tmdb_requests == ["101", "102", "103"]
+    assert client_log == ["enter", "exit"]
+
+    assert len(emitted_batches) == 3
+    first, second, sentinel = emitted_batches
+    assert isinstance(first, list)
+    assert isinstance(second, list)
+    assert sentinel is None
+    assert [item.plex.rating_key for item in first] == ["1", "2"]
+    assert [item.plex.rating_key for item in second] == ["3"]
+    assert all(item.imdb is not None for item in first + second)
+    assert all(item.tmdb is not None for item in first + second)
+
+
+def test_enrichment_stage_handles_missing_external_ids(monkeypatch):
+    imdb_requests: list[list[str]] = []
+    tmdb_requests: list[str] = []
+
+    async def fake_fetch_imdb_batch(client, imdb_ids):
+        imdb_requests.append(list(imdb_ids))
+        return {
+            imdb_id: IMDbTitle(id=imdb_id, type="movie", primaryTitle=f"IMDb {imdb_id}")
+            for imdb_id in imdb_ids
+        }
+
+    async def fake_fetch_tmdb_movie(client, tmdb_id, api_key):
+        tmdb_requests.append(tmdb_id)
+        return TMDBMovie.model_validate({"id": int(tmdb_id), "title": tmdb_id})
+
+    monkeypatch.setattr(
+        "mcp_plex.loader.pipeline.enrichment._fetch_imdb_batch",
+        fake_fetch_imdb_batch,
+    )
+    monkeypatch.setattr(
+        "mcp_plex.loader.pipeline.enrichment._fetch_tmdb_movie",
+        fake_fetch_tmdb_movie,
+    )
+
+    async def scenario() -> list[AggregatedItem]:
+        ingest_queue: asyncio.Queue = asyncio.Queue()
+        persistence_queue: asyncio.Queue = asyncio.Queue()
+
+        stage = EnrichmentStage(
+            http_client_factory=lambda: _FakeClient([]),
+            tmdb_api_key="token",
+            ingest_queue=ingest_queue,
+            persistence_queue=persistence_queue,
+            imdb_retry_queue=IMDbRetryQueue(),
+            movie_batch_size=5,
+            episode_batch_size=10,
+        )
+
+        movies = [
+            _FakeMovie("1", imdb_id="tt1", tmdb_id="201"),
+            _FakeMovie("2"),
+        ]
+        await ingest_queue.put(MovieBatch(movies=movies))
+        await ingest_queue.put(INGEST_DONE)
+
+        await stage.run()
+
+        payload = await persistence_queue.get()
+        assert isinstance(payload, list)
+        await persistence_queue.get()  # sentinel
+        return payload
+
+    aggregated = asyncio.run(scenario())
+
+    assert imdb_requests == [["tt1"]]
+    assert tmdb_requests == ["201"]
+    assert aggregated[0].imdb is not None and aggregated[0].tmdb is not None
+    assert aggregated[1].imdb is None and aggregated[1].tmdb is None

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.64"
+version = "0.26.65"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- port the movie batch handler and metadata aggregation from the legacy loader into the new pipeline enrichment stage
- swap global HTTP client usage for the injected factory to bundle external requests safely and emit persistence batches
- extend enrichment stage tests to cover TMDb/IMDb lookups, missing ID handling, and queue emission while bumping the project version

## Why
- the enrichment stage needed real movie metadata enrichment logic and must avoid the legacy global HTTP client
- ensuring batching via the injected client keeps external calls rate-limit friendly and unblocks downstream persistence work

## Affects
- loader pipeline enrichment stage implementation and its unit tests
- project metadata versions (pyproject, docker manifest, uv.lock)

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- Updated module docstring; no additional documentation changes required

------
https://chatgpt.com/codex/tasks/task_e_68e2b958c8208328903befed8d260950