### PR TITLE
feat: integrate persistence stage upsert orchestration

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.68"
+version = "0.26.69"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.68"
+version = "0.26.69"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_persistence_stage.py
+++ b/tests/test_persistence_stage.py
@@ -1,11 +1,20 @@
 import asyncio
+from typing import Any
 
+import pytest
+
+from mcp_plex.loader import _upsert_in_batches
 from mcp_plex.loader.pipeline.channels import PersistenceQueue
 from mcp_plex.loader.pipeline.persistence import PersistenceStage
 
 
 class _FakeQdrantClient:
-    pass
+    async def upsert(self, *, collection_name: str, points: list[Any]) -> None:
+        raise NotImplementedError
+
+
+async def _noop_upsert(_: list[Any]) -> None:
+    await asyncio.sleep(0)
 
 
 def test_persistence_stage_logger_name() -> None:
@@ -23,6 +32,9 @@ def test_persistence_stage_logger_name() -> None:
             persistence_queue=persistence_queue,
             retry_queue=retry_queue,
             upsert_semaphore=semaphore,
+            upsert_buffer_size=2,
+            upsert_fn=_noop_upsert,
+            on_batch_complete=None,
         )
         return stage.logger.name
 
@@ -32,7 +44,13 @@ def test_persistence_stage_logger_name() -> None:
 
 
 def test_persistence_stage_holds_dependencies() -> None:
-    async def scenario() -> tuple[PersistenceStage, _FakeQdrantClient, PersistenceQueue, asyncio.Queue, asyncio.Semaphore]:
+    async def scenario() -> tuple[
+        PersistenceStage,
+        _FakeQdrantClient,
+        PersistenceQueue,
+        asyncio.Queue,
+        asyncio.Semaphore,
+    ]:
         client = _FakeQdrantClient()
         persistence_queue: PersistenceQueue = asyncio.Queue()
         retry_queue: asyncio.Queue = asyncio.Queue()
@@ -46,6 +64,9 @@ def test_persistence_stage_holds_dependencies() -> None:
             persistence_queue=persistence_queue,
             retry_queue=retry_queue,
             upsert_semaphore=semaphore,
+            upsert_buffer_size=3,
+            upsert_fn=_noop_upsert,
+            on_batch_complete=None,
         )
 
         return stage, client, persistence_queue, retry_queue, semaphore
@@ -59,3 +80,141 @@ def test_persistence_stage_holds_dependencies() -> None:
     assert stage.persistence_queue is persistence_queue
     assert stage.retry_queue is retry_queue
     assert stage.upsert_semaphore is semaphore
+
+
+def test_persistence_stage_upserts_batches() -> None:
+    async def scenario() -> tuple[list[list[int]], list[tuple[int, int, int]], int]:
+        persistence_queue: PersistenceQueue = asyncio.Queue()
+        retry_queue: asyncio.Queue = asyncio.Queue()
+        semaphore = asyncio.Semaphore(2)
+
+        processed: list[list[int]] = []
+
+        async def fake_upsert(batch: list[int]) -> None:
+            processed.append(list(batch))
+
+        completions: list[tuple[int, int, int]] = []
+
+        def on_batch_complete(worker_id: int, batch_size: int, queue_size: int) -> None:
+            completions.append((worker_id, batch_size, queue_size))
+
+        stage = PersistenceStage(
+            client=_FakeQdrantClient(),
+            collection_name="media-items",
+            dense_vector_name="dense",
+            sparse_vector_name="sparse",
+            persistence_queue=persistence_queue,
+            retry_queue=retry_queue,
+            upsert_semaphore=semaphore,
+            upsert_buffer_size=2,
+            upsert_fn=fake_upsert,
+            on_batch_complete=on_batch_complete,
+        )
+
+        workers = [asyncio.create_task(stage.run(worker_id)) for worker_id in range(2)]
+
+        await stage.enqueue_points([1, 2, 3])
+        await persistence_queue.join()
+
+        for _ in workers:
+            await persistence_queue.put(None)
+
+        await asyncio.gather(*workers)
+
+        return processed, completions, semaphore._value  # type: ignore[attr-defined]
+
+    processed, completions, semaphore_value = asyncio.run(scenario())
+
+    assert {tuple(batch) for batch in processed} == {(1, 2), (3,)}
+    assert sorted(batch_size for _, batch_size, _ in completions) == [1, 2]
+    assert completions[-1][2] == 0
+    assert semaphore_value == 2
+
+
+def test_persistence_stage_populates_retry_queue_on_failure() -> None:
+    async def scenario() -> list[list[int]]:
+        persistence_queue: PersistenceQueue = asyncio.Queue()
+        retry_queue: asyncio.Queue[list[list[int]]] = asyncio.Queue()
+        semaphore = asyncio.Semaphore(1)
+
+        class _FailingClient:
+            async def upsert(
+                self, *, collection_name: str, points: list[list[int]]
+            ) -> None:
+                raise RuntimeError("boom")
+
+        async def upsert_fn(batch: list[list[int]]) -> None:
+            await _upsert_in_batches(
+                _FailingClient(),
+                "media-items",
+                batch,
+                retry_queue=retry_queue,
+            )
+
+        stage = PersistenceStage(
+            client=_FakeQdrantClient(),
+            collection_name="media-items",
+            dense_vector_name="dense",
+            sparse_vector_name="sparse",
+            persistence_queue=persistence_queue,
+            retry_queue=retry_queue,
+            upsert_semaphore=semaphore,
+            upsert_buffer_size=10,
+            upsert_fn=upsert_fn,
+            on_batch_complete=None,
+        )
+
+        worker = asyncio.create_task(stage.run(0))
+
+        await stage.enqueue_points([[1, 2]])
+        await persistence_queue.join()
+        await persistence_queue.put(None)
+        await asyncio.gather(worker)
+
+        failures: list[list[int]] = []
+        while not retry_queue.empty():
+            failures.append(await retry_queue.get())
+
+        return failures
+
+    failures = asyncio.run(scenario())
+
+    assert failures == [[[1, 2]]]
+
+
+def test_persistence_stage_releases_semaphore_on_upsert_error() -> None:
+    async def scenario() -> int:
+        persistence_queue: PersistenceQueue = asyncio.Queue()
+        retry_queue: asyncio.Queue = asyncio.Queue()
+        semaphore = asyncio.Semaphore(1)
+
+        async def failing_upsert(batch: list[int]) -> None:
+            raise RuntimeError("boom")
+
+        stage = PersistenceStage(
+            client=_FakeQdrantClient(),
+            collection_name="media-items",
+            dense_vector_name="dense",
+            sparse_vector_name="sparse",
+            persistence_queue=persistence_queue,
+            retry_queue=retry_queue,
+            upsert_semaphore=semaphore,
+            upsert_buffer_size=5,
+            upsert_fn=failing_upsert,
+            on_batch_complete=None,
+        )
+
+        worker = asyncio.create_task(stage.run(0))
+
+        await stage.enqueue_points([1])
+
+        with pytest.raises(RuntimeError):
+            await worker
+
+        await asyncio.wait_for(persistence_queue.join(), timeout=1)
+
+        return semaphore._value  # type: ignore[attr-defined]
+
+    semaphore_value = asyncio.run(scenario())
+
+    assert semaphore_value == 1

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.68"
+version = "0.26.69"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- wire the loader pipeline to the persistence stage so the stage manages batching, queue emission, and concurrent upsert workers
- expand the persistence stage to chunk point batches, run Qdrant writes with retry callbacks, and notify the pipeline for progress accounting
- add unit tests covering successful upserts, retry queue population, semaphore release on errors, and bump the project version to 0.26.69

## Testing
- uv run ruff check .
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2d3eef50c83289cafe78ad1d1452e