### PR TITLE
feat: alias LoaderPipeline to LoaderOrchestrator

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.71"
+version = "0.26.72"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.71"
+version = "0.26.72"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_loader_alias.py
+++ b/tests/test_loader_alias.py
@@ -1,0 +1,17 @@
+"""Compatibility tests for loader public API aliases."""
+
+import importlib
+import warnings
+
+
+def test_loader_pipeline_alias_emits_deprecation_warning() -> None:
+    """The legacy LoaderPipeline export should point at the orchestrator."""
+
+    module = importlib.import_module("mcp_plex.loader")
+    module = importlib.reload(module)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        alias = getattr(module, "LoaderPipeline")
+
+    assert alias is module.LoaderOrchestrator
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)

--- a/tests/test_loader_logging.py
+++ b/tests/test_loader_logging.py
@@ -128,17 +128,17 @@ def test_run_ensures_collection_before_loading(monkeypatch):
 
     monkeypatch.setattr(loader, "_ensure_collection", fake_ensure)
     sample_dir = Path(__file__).resolve().parents[1] / "sample-data"
-    original_execute = loader.LoaderPipeline.execute
+    original_execute = loader.LegacyLoaderPipeline.execute
 
     async def fake_execute(self):
         order.append("execute")
         self._items = []
 
-    monkeypatch.setattr(loader.LoaderPipeline, "execute", fake_execute)
+    monkeypatch.setattr(loader.LegacyLoaderPipeline, "execute", fake_execute)
 
     asyncio.run(loader.run(None, None, None, sample_dir, None, None))
 
     assert order and order[0] == "ensure"
     assert "execute" in order
 
-    monkeypatch.setattr(loader.LoaderPipeline, "execute", original_execute)
+    monkeypatch.setattr(loader.LegacyLoaderPipeline, "execute", original_execute)

--- a/tests/test_loader_unit.py
+++ b/tests/test_loader_unit.py
@@ -13,7 +13,7 @@ import pytest
 from mcp_plex import loader
 from mcp_plex.loader.imdb_cache import IMDbCache
 from mcp_plex.loader import (
-    LoaderPipeline,
+    LegacyLoaderPipeline as LoaderPipeline,
     _build_plex_item,
     _extract_external_ids,
     _fetch_imdb,

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.71"
+version = "0.26.72"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- update `mcp_plex.loader` to document the orchestrator-first design and import `LoaderOrchestrator`
- expose `LegacyLoaderPipeline` for the CLI, provide a deprecated `LoaderPipeline` alias via `__getattr__`, and update codepaths to use the legacy name
- refresh tests to consume the legacy class explicitly and add coverage ensuring the deprecated import warns while returning the orchestrator
- bump the project version metadata and regenerate `uv.lock`

## Why
- align the loader package’s public API with the new orchestrator-centric implementation without breaking existing imports

## Affects
- loader package exports, CLI wiring, backwards-compatibility test coverage, and version metadata

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- Updated the loader module docstring; no separate docs required


------
https://chatgpt.com/codex/tasks/task_e_68e2ef6e94288328b1ad63f8863ecc35