### PR TITLE
Refactor loader pipeline package exports

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.72"
+version = "0.26.73"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/loader/pipeline/__init__.py
+++ b/mcp_plex/loader/pipeline/__init__.py
@@ -1,34 +1,68 @@
-"""Loader pipeline package exports placeholder interfaces for pipeline stages."""
+"""Expose the concrete loader pipeline stages and shared channel helpers."""
 
 from __future__ import annotations
 
-from typing import Protocol
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
 
+from .channels import (
+    EpisodeBatch,
+    IMDbRetryQueue,
+    IngestBatch,
+    IngestQueue,
+    INGEST_DONE,
+    MovieBatch,
+    PERSIST_DONE,
+    PersistenceQueue,
+    SampleBatch,
+    chunk_sequence,
+    require_positive,
+)
 
-class ChannelDefinition(Protocol):
-    """Placeholder protocol for defining loader pipeline channels."""
-
-
-class IngestionStage(Protocol):
-    """Placeholder protocol for pipeline ingestion stage implementations."""
-
-
-class EnrichmentStage(Protocol):
-    """Placeholder protocol for pipeline enrichment stage implementations."""
-
-
-class PersistenceStage(Protocol):
-    """Placeholder protocol for pipeline persistence stage implementations."""
-
-
-class PipelineOrchestrator(Protocol):
-    """Placeholder protocol for orchestrating loader pipeline stages."""
-
+if TYPE_CHECKING:
+    from .enrichment import EnrichmentStage
+    from .ingestion import IngestionStage
+    from .orchestrator import LoaderOrchestrator
+    from .persistence import PersistenceStage
 
 __all__ = [
-    "ChannelDefinition",
     "IngestionStage",
     "EnrichmentStage",
     "PersistenceStage",
-    "PipelineOrchestrator",
+    "LoaderOrchestrator",
+    "MovieBatch",
+    "EpisodeBatch",
+    "SampleBatch",
+    "IngestBatch",
+    "IngestQueue",
+    "PersistenceQueue",
+    "INGEST_DONE",
+    "PERSIST_DONE",
+    "IMDbRetryQueue",
+    "chunk_sequence",
+    "require_positive",
 ]
+
+_STAGE_MODULES = {
+    "IngestionStage": ".ingestion",
+    "EnrichmentStage": ".enrichment",
+    "PersistenceStage": ".persistence",
+    "LoaderOrchestrator": ".orchestrator",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import pipeline stage classes on first access."""
+
+    if name in _STAGE_MODULES:
+        module = import_module(f"{__name__}{_STAGE_MODULES[name]}")
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return module attributes for introspection tools."""
+
+    return sorted(set(globals()) | set(__all__))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.72"
+version = "0.26.73"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.72"
+version = "0.26.73"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- replace the loader pipeline package placeholders with concrete stage exports and shared channel helpers
- bump the project version metadata to 0.26.73

## Testing
- uv run ruff check .
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e32d1b4cc48328b39087a00c83c23b