### PR TITLE
Log staged loader workflow startup

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.73"
+version = "0.26.74"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/loader/__init__.py
+++ b/mcp_plex/loader/__init__.py
@@ -1564,6 +1564,7 @@ async def run(
             max_concurrent_upserts=_qdrant_max_concurrent_upserts,
             imdb_retry_queue=_IMDbRetryQueue(),
         )
+        logger.info("Starting ingestion, enrichment, and persistence stages")
         logger.info("Starting staged loader (sample mode)")
         await orchestrator.run()
     else:
@@ -1589,6 +1590,7 @@ async def run(
             upsert_buffer_size=upsert_buffer_size,
             max_concurrent_upserts=_qdrant_max_concurrent_upserts,
         )
+        logger.info("Starting ingestion, enrichment, and persistence stages")
         logger.info("Starting staged loader (Plex mode)")
         await orchestrator.run()
     logger.info("Loaded %d items", len(items))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.73"
+version = "0.26.74"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"


### PR DESCRIPTION
## Summary
- add explicit logging after building the staged loader orchestrator so the ingestion, enrichment, and persistence phases are visible in the CLI logs
- bump the project version to 0.26.74 to reflect the change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e33b45d1988328a48743d2f39f0e71