### PR TITLE
refactor: remove loader global state

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.78"
+version = "0.26.79"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/loader/pipeline/channels.py
+++ b/mcp_plex/loader/pipeline/channels.py
@@ -124,19 +124,6 @@ class IMDbRetryQueue(asyncio.Queue[str]):
         return list(self._items)
 
 
-# Backwards-compatible aliases for private imports while callers migrate.
-_MovieBatch = MovieBatch
-_EpisodeBatch = EpisodeBatch
-_SampleBatch = SampleBatch
-_IngestBatch = IngestBatch
-_INGEST_DONE = INGEST_DONE
-_PERSIST_DONE = PERSIST_DONE
-_IngestQueue = IngestQueue
-_PersistenceQueue = PersistenceQueue
-_require_positive = require_positive
-_chunk_sequence = chunk_sequence
-_IMDbRetryQueue = IMDbRetryQueue
-
 __all__ = [
     "MovieBatch",
     "EpisodeBatch",
@@ -149,15 +136,4 @@ __all__ = [
     "require_positive",
     "chunk_sequence",
     "IMDbRetryQueue",
-    "_MovieBatch",
-    "_EpisodeBatch",
-    "_SampleBatch",
-    "_IngestBatch",
-    "_INGEST_DONE",
-    "_PERSIST_DONE",
-    "_IngestQueue",
-    "_PersistenceQueue",
-    "_require_positive",
-    "_chunk_sequence",
-    "_IMDbRetryQueue",
 ]

--- a/mcp_plex/loader/pipeline/ingestion.py
+++ b/mcp_plex/loader/pipeline/ingestion.py
@@ -18,7 +18,6 @@ from .channels import (
     MovieBatch,
     SampleBatch,
     chunk_sequence,
-    _chunk_sequence,
 )
 
 
@@ -122,7 +121,7 @@ class IngestionStage:
         movies_source = movies_attr() if callable(movies_attr) else movies_attr
         movies = list(movies_source)
         for batch_index, chunk in enumerate(
-            _chunk_sequence(movies, movie_batch_size), start=1
+            chunk_sequence(movies, movie_batch_size), start=1
         ):
             batch_movies = list(chunk)
             if not batch_movies:
@@ -150,7 +149,7 @@ class IngestionStage:
             )
             episodes = list(episodes_source)
             for batch_index, chunk in enumerate(
-                _chunk_sequence(episodes, episode_batch_size), start=1
+                chunk_sequence(episodes, episode_batch_size), start=1
             ):
                 batch_episodes = list(chunk)
                 if not batch_episodes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.78"
+version = "0.26.79"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_loader_logging.py
+++ b/tests/test_loader_logging.py
@@ -71,7 +71,6 @@ def test_run_rejects_invalid_upsert_buffer_size(monkeypatch):
 def test_run_limits_concurrent_upserts(monkeypatch):
     monkeypatch.setattr(loader, "AsyncQdrantClient", DummyClient)
     sample_dir = Path(__file__).resolve().parents[1] / "sample-data"
-    monkeypatch.setattr(loader, "_qdrant_max_concurrent_upserts", 1)
 
     concurrency = {"current": 0, "max": 0}
     started = asyncio.Queue()
@@ -101,7 +100,16 @@ def test_run_limits_concurrent_upserts(monkeypatch):
 
     async def invoke():
         run_task = asyncio.create_task(
-            loader.run(None, None, None, sample_dir, None, None, upsert_buffer_size=1)
+            loader.run(
+                None,
+                None,
+                None,
+                sample_dir,
+                None,
+                None,
+                upsert_buffer_size=1,
+                max_concurrent_upserts=1,
+            )
         )
         await asyncio.wait_for(started.get(), timeout=1)
         assert not third_requested.is_set()

--- a/tests/test_persistence_stage.py
+++ b/tests/test_persistence_stage.py
@@ -148,6 +148,7 @@ def test_persistence_stage_populates_retry_queue_on_failure() -> None:
                 _FailingClient(),
                 "media-items",
                 batch,
+                batch_size=1,
                 retry_queue=retry_queue,
             )
 

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.78"
+version = "0.26.79"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- replace mutable loader globals with runtime configuration objects and updated helpers
- drop the private channel aliases and teach ingestion to use the shared types directly
- update loader tests and helpers to pass explicit configuration and bump the project version

## Why
- keep configuration near its usage so IMDb and Qdrant helpers can be reused without global mutation

## Affects
- loader runtime configuration, pipeline channels/ingestion, loader unit/integration tests

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- not needed

------
https://chatgpt.com/codex/tasks/task_e_68e355a592b48328a7c276e8d20d3289