### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "0.26.79"
+version = "1.0.0"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "0.26.79"
+version = "1.0.0"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "0.26.79"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- bump the project version to 1.0.0 following the major refactor
- align the Docker dependency manifest with the new release number
- regenerate `uv.lock` with the updated version metadata

## Why
- ensure the package semver reflects the recent major refactor
- keep all manifests in sync for builds and packaging

## Affects
- release metadata in `pyproject.toml`
- Docker build dependency manifest
- lockfile metadata used for dependency resolution

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- not required for this change


------
https://chatgpt.com/codex/tasks/task_e_68e35b2e7b3c8328891d211109dd7f84