### PR TITLE
feat: expand loader pipeline logging instrumentation

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "1.0.1"
+version = "1.0.2"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "1.0.1"
+version = "1.0.2"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_loader_logging.py
+++ b/tests/test_loader_logging.py
@@ -34,9 +34,13 @@ def test_run_logs_upsert(monkeypatch, caplog):
     with caplog.at_level(logging.INFO):
         asyncio.run(loader.run(None, None, None, sample_dir, None, None))
     assert "Starting staged loader (sample mode)" in caplog.text
+    assert "Launching loader orchestrator" in caplog.text
+    assert "Starting ingestion stage (sample mode)" in caplog.text
     assert "Upsert worker 0 handling 2 points" in caplog.text
     assert "Upsert worker 0 processed 2 items" in caplog.text
     assert "Loaded 2 items" in caplog.text
+    assert "Ingestion stage finished" in caplog.text
+    assert "Loader orchestrator run completed successfully" in caplog.text
 
 
 def test_run_logs_no_points(monkeypatch, caplog):
@@ -47,6 +51,7 @@ def test_run_logs_no_points(monkeypatch, caplog):
         asyncio.run(loader.run(None, None, None, sample_dir, None, None))
     assert "Loaded 0 items" in caplog.text
     assert "No points to upsert" in caplog.text
+    assert "Ingestion stage finished" in caplog.text
 
 
 def test_run_rejects_invalid_upsert_buffer_size(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- add detailed lifecycle logging across the loader orchestrator and ingestion, enrichment, and persistence stages
- extend loader logging tests to assert the new instrumentation and cover additional ingestion stage messages
- bump the project version to 1.0.2 to capture the new logging capabilities

## Why
- richer pipeline visibility makes it easier to diagnose why staged loads finish without producing items

## Affects
- loader pipeline logging, associated unit tests, and version metadata for release tracking

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- not required for logging-only changes

------
https://chatgpt.com/codex/tasks/task_e_68e37b7c5a288328825b73120f288668