### PR TITLE
feat: type Plex ingestion pipeline

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "1.0.2"
+version = "1.0.3"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/loader/pipeline/channels.py
+++ b/mcp_plex/loader/pipeline/channels.py
@@ -17,8 +17,10 @@ from ...common.validation import require_positive
 
 try:  # Only import plexapi when available; the sample data mode does not require it.
     from plexapi.base import PlexPartialObject
+    from plexapi.video import Episode, Movie, Show
 except Exception:
     PlexPartialObject = object  # type: ignore[assignment]
+    Episode = Movie = Show = PlexPartialObject  # type: ignore[assignment]
 
 T = TypeVar("T")
 
@@ -46,15 +48,15 @@ else:  # pragma: no cover - runtime fallback for typing-only alias
 class MovieBatch:
     """Batch of Plex movie items pending metadata enrichment."""
 
-    movies: list["PlexPartialObject"]
+    movies: list["Movie"]
 
 
 @dataclass(slots=True)
 class EpisodeBatch:
     """Batch of Plex episodes along with their parent show."""
 
-    show: "PlexPartialObject"
-    episodes: list["PlexPartialObject"]
+    show: "Show"
+    episodes: list["Episode"]
 
 
 @dataclass(slots=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "1.0.2"
+version = "1.0.3"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- type the ingestion stage and batch containers with plexapi server and video classes
- fetch movies and shows via library sections and iterate seasons/episodes through the typed API
- refresh the ingestion unit test to assert section usage and typed batches
- bump project version to 1.0.3 and sync dependency manifests

## Why
- align ingestion with the concrete plexapi interfaces so downstream enrichment receives correctly typed media objects
- verify that ingestion targets the intended Plex library sections

## Affects
- loader pipeline ingestion and channel helpers
- ingestion unit tests and project metadata versions

## Testing
- `uv run pytest`

## Documentation
- none required

------
https://chatgpt.com/codex/tasks/task_e_68e447dd39e48328a38140e6ac97e72c