### PR TITLE
Cache media payloads under external identifiers

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "1.0.8"
+version = "1.0.9"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "1.0.8"
+version = "1.0.9"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "1.0.8"
+version = "1.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- store media payloads in the cache under the lookup identifier plus Plex, IMDb, TMDb, and TVDb IDs when available
- add coverage to ensure repeated lookups by external identifiers reuse the cache instead of calling `_find_records`
- bump the project version to 1.0.9 and refresh the uv lock file

## Why
- prevent redundant Qdrant lookups when resolving the same media via different identifiers

## Affects
- `mcp_plex/server/__init__.py`
- `tests/test_server.py`
- project metadata (`pyproject.toml`, `docker/pyproject.deps.toml`, `uv.lock`)

## Testing
- `uv run pytest`

## Documentation
- none required

------
https://chatgpt.com/codex/tasks/task_e_68e456f7ab18832893b21d46b49a58c8