### PR TITLE
fix: warn when IMDb cache JSON decoding fails

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "1.0.9"
+version = "1.0.10"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "1.0.11"
+version = "1.0.12"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "1.0.10"
+version = "1.0.11"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/loader/imdb_cache.py
+++ b/mcp_plex/loader/imdb_cache.py
@@ -17,7 +17,7 @@ class IMDbCache:
         if path.exists():
             try:
                 raw_contents = path.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError) as exc:
+            except Exception as exc:  # noqa: BLE001 - ensure any read failure is surfaced
                 self._logger.warning(
                     "Failed to read IMDb cache from %s; starting with empty cache.",
                     path,
@@ -26,7 +26,7 @@ class IMDbCache:
             else:
                 try:
                     self._data = json.loads(raw_contents)
-                except json.JSONDecodeError as exc:
+                except (json.JSONDecodeError, UnicodeError) as exc:
                     self._logger.warning(
                         "Failed to decode IMDb cache JSON from %s; starting with empty cache.",
                         path,

--- a/mcp_plex/loader/imdb_cache.py
+++ b/mcp_plex/loader/imdb_cache.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 
 class IMDbCache:
@@ -13,26 +13,25 @@ class IMDbCache:
 
     def __init__(self, path: Path) -> None:
         self.path = path
-        self._data: Dict[str, Any]
+        self._data: dict[str, Any] = {}
         if path.exists():
             try:
-                self._data = json.loads(path.read_text())
-            except json.JSONDecodeError as exc:
-                self._logger.warning(
-                    "Failed to load IMDb cache from %s; starting with empty cache.",
-                    path,
-                    exc_info=exc,
-                )
-                self._data = {}
-            except OSError as exc:
+                raw_contents = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as exc:
                 self._logger.warning(
                     "Failed to read IMDb cache from %s; starting with empty cache.",
                     path,
                     exc_info=exc,
                 )
-                self._data = {}
-        else:
-            self._data = {}
+            else:
+                try:
+                    self._data = json.loads(raw_contents)
+                except json.JSONDecodeError as exc:
+                    self._logger.warning(
+                        "Failed to decode IMDb cache JSON from %s; starting with empty cache.",
+                        path,
+                        exc_info=exc,
+                    )
 
     def get(self, imdb_id: str) -> dict[str, Any] | None:
         """Return cached data for ``imdb_id`` if present."""

--- a/mcp_plex/loader/imdb_cache.py
+++ b/mcp_plex/loader/imdb_cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any, Dict
 
@@ -8,13 +9,27 @@ from typing import Any, Dict
 class IMDbCache:
     """Simple persistent cache for IMDb API responses."""
 
+    _logger = logging.getLogger(__name__)
+
     def __init__(self, path: Path) -> None:
         self.path = path
         self._data: Dict[str, Any]
         if path.exists():
             try:
                 self._data = json.loads(path.read_text())
-            except Exception:
+            except json.JSONDecodeError as exc:
+                self._logger.warning(
+                    "Failed to load IMDb cache from %s; starting with empty cache.",
+                    path,
+                    exc_info=exc,
+                )
+                self._data = {}
+            except OSError as exc:
+                self._logger.warning(
+                    "Failed to read IMDb cache from %s; starting with empty cache.",
+                    path,
+                    exc_info=exc,
+                )
                 self._data = {}
         else:
             self._data = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "1.0.11"
+version = "1.0.12"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "1.0.10"
+version = "1.0.11"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "1.0.9"
+version = "1.0.10"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_imdb_cache.py
+++ b/tests/test_imdb_cache.py
@@ -37,10 +37,16 @@ def test_imdb_cache_loads_existing_and_persists(tmp_path: Path):
     }
 
 
-def test_imdb_cache_invalid_file(tmp_path: Path):
+def test_imdb_cache_invalid_file_logs_warning(tmp_path: Path, caplog):
     path = tmp_path / "cache.json"
     path.write_text("not json")
-    cache = IMDbCache(path)
+    with caplog.at_level("WARNING"):
+        cache = IMDbCache(path)
+    assert any(
+        record.name == "mcp_plex.loader.imdb_cache"
+        and "Failed to load IMDb cache" in record.getMessage()
+        for record in caplog.records
+    )
     assert cache.get("tt0111161") is None
     cache.set("tt0111161", {"id": "tt0111161"})
     assert cache.get("tt0111161") == {"id": "tt0111161"}

--- a/tests/test_imdb_cache.py
+++ b/tests/test_imdb_cache.py
@@ -44,7 +44,22 @@ def test_imdb_cache_invalid_file_logs_warning(tmp_path: Path, caplog):
         cache = IMDbCache(path)
     assert any(
         record.name == "mcp_plex.loader.imdb_cache"
-        and "Failed to load IMDb cache" in record.getMessage()
+        and "Failed to decode IMDb cache JSON" in record.getMessage()
+        for record in caplog.records
+    )
+    assert cache.get("tt0111161") is None
+    cache.set("tt0111161", {"id": "tt0111161"})
+    assert cache.get("tt0111161") == {"id": "tt0111161"}
+
+
+def test_imdb_cache_invalid_encoding_logs_warning(tmp_path: Path, caplog):
+    path = tmp_path / "cache.json"
+    path.write_bytes(b"\xff\xff")
+    with caplog.at_level("WARNING"):
+        cache = IMDbCache(path)
+    assert any(
+        record.name == "mcp_plex.loader.imdb_cache"
+        and "Failed to read IMDb cache" in record.getMessage()
         for record in caplog.records
     )
     assert cache.get("tt0111161") is None

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "1.0.11"
+version = "1.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "1.0.9"
+version = "1.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "1.0.10"
+version = "1.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- log a warning and fall back to an empty store when the IMDb cache fails to decode JSON
- add a regression test that asserts the warning is emitted for corrupt cache files
- bump the project version to 1.0.10 and mirror the change in dependent manifests

## Why
- prevent silent cache resets from hiding corrupt cache files and make debugging loader issues easier

## Affects
- IMDb cache loader behavior and tests
- project version metadata

## Testing
- `uv run ruff check .`
- `uv run pytest tests/test_imdb_cache.py`

## Documentation
- No documentation updates needed

------
https://chatgpt.com/codex/tasks/task_e_68e45963eec08328905f9a8fdcf0d1fd