### PR TITLE
Add offset playback coverage for play media tool

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -285,6 +285,25 @@ def test_play_media_with_alias(monkeypatch):
         assert play_call["kwargs"]["machineIdentifier"] == "server-001"
         assert play_call["kwargs"]["offset"] == 0
 
+        play_requests.clear()
+        fetch_requests.clear()
+
+        offset_seconds = 37
+        offset_result = asyncio.run(
+            server.play_media.fn(
+                identifier="49915", player="Living Room", offset_seconds=offset_seconds
+            )
+        )
+
+        assert offset_result["player"] == "Living Room"
+        assert offset_result["rating_key"] == "49915"
+        assert offset_result["offset_seconds"] == offset_seconds
+        assert fetch_requests == ["/library/metadata/49915"]
+        assert play_requests, "Expected plexapi playMedia call with offset"
+        offset_call = play_requests[0]
+        assert offset_call["kwargs"]["machineIdentifier"] == "server-001"
+        assert offset_call["kwargs"]["offset"] == offset_seconds * 1000
+
 
 def test_play_media_requires_player_capability(monkeypatch):
     monkeypatch.setenv("PLEX_URL", "http://plex.test:32400")


### PR DESCRIPTION
## What
- extend the play media test to cover a non-zero offset
- verify the fake Plex client receives the expected millisecond offset and the tool response echoes the seconds value

## Why
- ensure the play media tool forwards offsets correctly and returns the requested offset to callers

## Affects
- tests

## Testing
- uv run pytest tests/test_server.py::test_play_media_with_alias

## Documentation
- not needed

------
https://chatgpt.com/codex/tasks/task_e_68e489b9f2888328b3c649f577f4363b