### PR TITLE
refactor: tighten loader typing

### DIFF
--- a/mcp_plex/loader/AGENTS.md
+++ b/mcp_plex/loader/AGENTS.md
@@ -27,3 +27,7 @@
   - `LoaderOrchestrator` must be initialised with the three stage instances, the ingest queue, the persistence queue, and the number of persistence workers (the CLI's `max_concurrent_upserts`).
 - Convert `AggregatedItem` batches into Qdrant `PointStruct` objects with `build_point` before handing them to the persistence stage's `enqueue_points` helper.
 - Prefer explicit keyword arguments when threading CLI options into stage constructors so the mapping is obvious to future readers.
+
+## Typing Guidelines
+- Avoid introducing new ``Any`` or bare ``object`` annotations in loader modules. Use ``TypedDict`` definitions, ``Protocol`` classes, or precise unions instead.
+- When wider typing is unavoidable, leave a brief comment explaining why the loosening is necessary so future contributors can revisit it.

--- a/mcp_plex/loader/imdb_cache.py
+++ b/mcp_plex/loader/imdb_cache.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TypeAlias, cast
+
+from ..common.types import IMDbTitle
+
+JSONScalar: TypeAlias = str | int | float | bool | None
+JSONValue: TypeAlias = (
+    JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+)
+
+
+CachedIMDbPayload: TypeAlias = IMDbTitle | JSONValue
 
 
 class IMDbCache:
@@ -13,7 +23,7 @@ class IMDbCache:
 
     def __init__(self, path: Path) -> None:
         self.path = path
-        self._data: dict[str, Any] = {}
+        self._data: dict[str, CachedIMDbPayload] = {}
         if path.exists():
             try:
                 raw_contents = path.read_text(encoding="utf-8")
@@ -25,22 +35,37 @@ class IMDbCache:
                 )
             else:
                 try:
-                    self._data = json.loads(raw_contents)
+                    loaded = json.loads(raw_contents)
                 except (json.JSONDecodeError, UnicodeError) as exc:
                     self._logger.warning(
                         "Failed to decode IMDb cache JSON from %s; starting with empty cache.",
                         path,
                         exc_info=exc,
                     )
+                else:
+                    if isinstance(loaded, dict):
+                        self._data = {
+                            str(key): cast(CachedIMDbPayload, value)
+                            for key, value in loaded.items()
+                        }
+                    else:
+                        self._logger.warning(
+                            "IMDb cache at %s did not contain an object; ignoring its contents.",
+                            path,
+                        )
 
-    def get(self, imdb_id: str) -> dict[str, Any] | None:
+    def get(self, imdb_id: str) -> CachedIMDbPayload | None:
         """Return cached data for ``imdb_id`` if present."""
 
         return self._data.get(imdb_id)
 
-    def set(self, imdb_id: str, data: dict[str, Any]) -> None:
+    def set(self, imdb_id: str, data: CachedIMDbPayload) -> None:
         """Store ``data`` under ``imdb_id`` and persist to disk."""
 
         self._data[imdb_id] = data
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(self._data))
+        serialisable = {
+            key: value.model_dump() if isinstance(value, IMDbTitle) else value
+            for key, value in self._data.items()
+        }
+        self.path.write_text(json.dumps(serialisable))

--- a/mcp_plex/loader/pipeline/__init__.py
+++ b/mcp_plex/loader/pipeline/__init__.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from importlib import import_module
-from typing import TYPE_CHECKING, Any
-
 from .channels import (
     EpisodeBatch,
     IMDbRetryQueue,
@@ -19,11 +16,10 @@ from .channels import (
 )
 from ...common.validation import require_positive
 
-if TYPE_CHECKING:
-    from .enrichment import EnrichmentStage
-    from .ingestion import IngestionStage
-    from .orchestrator import LoaderOrchestrator
-    from .persistence import PersistenceStage
+from .enrichment import EnrichmentStage
+from .ingestion import IngestionStage
+from .orchestrator import LoaderOrchestrator
+from .persistence import PersistenceStage
 
 __all__ = [
     "IngestionStage",
@@ -42,27 +38,3 @@ __all__ = [
     "chunk_sequence",
     "require_positive",
 ]
-
-_STAGE_MODULES = {
-    "IngestionStage": ".ingestion",
-    "EnrichmentStage": ".enrichment",
-    "PersistenceStage": ".persistence",
-    "LoaderOrchestrator": ".orchestrator",
-}
-
-
-def __getattr__(name: str) -> Any:
-    """Lazily import pipeline stage classes on first access."""
-
-    if name in _STAGE_MODULES:
-        module = import_module(f"{__name__}{_STAGE_MODULES[name]}")
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__() -> list[str]:
-    """Return module attributes for introspection tools."""
-
-    return sorted(set(globals()) | set(__all__))

--- a/mcp_plex/loader/pipeline/channels.py
+++ b/mcp_plex/loader/pipeline/channels.py
@@ -12,7 +12,6 @@ from collections import deque
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
-    Any,
     Final,
     Iterable,
     Literal,
@@ -46,8 +45,8 @@ PersistenceSentinel: TypeAlias = Literal[PERSIST_DONE]
 
 if TYPE_CHECKING:
     PersistencePayload: TypeAlias = list[models.PointStruct]
-else:  # pragma: no cover - runtime fallback for typing-only alias
-    PersistencePayload: TypeAlias = list[Any]
+
+PersistencePayload: TypeAlias = list["models.PointStruct"]
 
 
 @dataclass(slots=True)

--- a/mcp_plex/loader/pipeline/ingestion.py
+++ b/mcp_plex/loader/pipeline/ingestion.py
@@ -23,6 +23,7 @@ from .channels import (
     enqueue_nowait,
 )
 
+from plexapi.library import LibrarySection
 from plexapi.server import PlexServer
 from plexapi.video import Episode, Movie, Season, Show
 
@@ -171,12 +172,9 @@ class IngestionStage:
         library = plex_server.library
 
         def _log_discovered_count(
-            *, section: object, descriptor: str
+            *, section: LibrarySection, descriptor: str
         ) -> int | None:
-            try:
-                total = getattr(section, "totalSize")  # type: ignore[assignment]
-            except Exception:  # pragma: no cover - defensive guard
-                total = None
+            total = getattr(section, "totalSize", None)
             if isinstance(total, int):
                 logger.info(
                     "Discovered %d Plex %s(s) for ingestion.",

--- a/mcp_plex/loader/pipeline/persistence.py
+++ b/mcp_plex/loader/pipeline/persistence.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Sequence
+from typing import Awaitable, Callable, Sequence, TypeAlias
 
 from .channels import (
     PERSIST_DONE,
@@ -14,13 +14,22 @@ from .channels import (
 )
 from ...common.validation import require_positive
 
-if TYPE_CHECKING:  # pragma: no cover - typing helpers only
+try:  # pragma: no cover - allow import to fail when qdrant_client is absent
     from qdrant_client import AsyncQdrantClient, models
+except ModuleNotFoundError:  # pragma: no cover - tooling without qdrant installed
+    class AsyncQdrantClient:  # type: ignore[too-few-public-methods]
+        """Fallback stub used when qdrant_client is unavailable."""
 
-    PersistencePayload = list[models.PointStruct]
-else:  # pragma: no cover - runtime fallback when qdrant_client is absent
-    AsyncQdrantClient = Any  # type: ignore[assignment]
-    PersistencePayload = list[Any]
+        pass
+
+    class _ModelsStub:  # type: ignore[too-few-public-methods]
+        class PointStruct:  # type: ignore[too-few-public-methods]
+            ...
+
+    models = _ModelsStub()  # type: ignore[assignment]
+
+
+PersistencePayload: TypeAlias = list["models.PointStruct"]
 
 
 class PersistenceStage:


### PR DESCRIPTION
## What
- tighten loader runtime configuration typing by adding typed IMDb throttles and Qdrant payload definitions
- update pipeline stages to rely on concrete protocols and forward-referenced Qdrant payloads while refining loader ingestion helpers
- refresh enrichment-stage tests and loader agent guidance to cover the stricter typing contracts

## Why
- removing `Any` fallbacks and clarifying runtime protocols makes the staged loader easier to reason about and safer to extend

## Affects
- loader orchestration helpers, pipeline stages, and enrichment-stage tests

## Testing
- `uv run pytest tests/test_enrichment_stage.py tests/test_loader_orchestrator.py tests/test_loader_integration.py`

## Documentation
- updated `mcp_plex/loader/AGENTS.md` typing guidance


------
https://chatgpt.com/codex/tasks/task_e_68e4900da3e48328bc800e41c3843b03