### PR TITLE
feat: tighten cache payload typing and validation

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "1.0.18"
+version = "1.0.19"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/common/AGENTS.md
+++ b/mcp_plex/common/AGENTS.md
@@ -4,4 +4,5 @@
 - `mcp_plex.common` provides shared cache helpers, data models, and utility types consumed by both the loader and the server packages.
 - Keep shared logic decoupled from CLI wiring so it can be imported safely by tests and other packages.
 - Update this module when adding reusable functionality to avoid duplicating code between the loader and server implementations.
+- Use the `JSONValue` and related aliases in `types.py` when exchanging cached payloads or structured JSON-like data. Media caches and downstream consumers expect payload dictionaries to resolve to `dict[str, JSONValue]` without falling back to ``Any``.
 

--- a/mcp_plex/common/__init__.py
+++ b/mcp_plex/common/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .cache import MediaCache
+from .types import JSONValue
 from .validation import require_positive
 
-__all__ = ["MediaCache", "require_positive"]
+__all__ = ["MediaCache", "JSONValue", "require_positive"]

--- a/mcp_plex/common/cache.py
+++ b/mcp_plex/common/cache.py
@@ -2,7 +2,13 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import Any
+from typing import TypeVar
+
+from .types import JSONValue
+
+
+CachedPayload = dict[str, JSONValue]
+_CacheValueT = TypeVar("_CacheValueT")
 
 
 class MediaCache:
@@ -10,27 +16,31 @@ class MediaCache:
 
     def __init__(self, size: int = 128) -> None:
         self.size = size
-        self._payload: OrderedDict[str, dict[str, Any]] = OrderedDict()
+        self._payload: OrderedDict[str, CachedPayload] = OrderedDict()
         self._poster: OrderedDict[str, str] = OrderedDict()
         self._background: OrderedDict[str, str] = OrderedDict()
 
-    def _set(self, cache: OrderedDict, key: str, value: Any) -> None:
+    def _set(
+        self, cache: OrderedDict[str, _CacheValueT], key: str, value: _CacheValueT
+    ) -> None:
         if key in cache:
             cache.move_to_end(key)
         cache[key] = value
         while len(cache) > self.size:
             cache.popitem(last=False)
 
-    def _get(self, cache: OrderedDict, key: str) -> Any | None:
+    def _get(
+        self, cache: OrderedDict[str, _CacheValueT], key: str
+    ) -> _CacheValueT | None:
         if key in cache:
             cache.move_to_end(key)
             return cache[key]
         return None
 
-    def get_payload(self, key: str) -> dict[str, Any] | None:
+    def get_payload(self, key: str) -> CachedPayload | None:
         return self._get(self._payload, key)
 
-    def set_payload(self, key: str, value: dict[str, Any]) -> None:
+    def set_payload(self, key: str, value: CachedPayload) -> None:
         self._set(self._payload, key, value)
 
     def get_poster(self, key: str) -> str | None:

--- a/mcp_plex/common/types.py
+++ b/mcp_plex/common/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Literal, Optional
+from typing import List, Literal, Mapping, MutableMapping, Optional, Sequence, TypeAlias
 
 from pydantic import BaseModel, Field
 
@@ -176,3 +176,8 @@ __all__ = [
     "AggregatedItem",
     "ExternalIDs",
 ]
+JSONScalar: TypeAlias = str | int | float | bool | None
+JSONValue: TypeAlias = JSONScalar | Sequence["JSONValue"] | Mapping[str, "JSONValue"]
+JSONMapping: TypeAlias = Mapping[str, JSONValue]
+MutableJSONMapping: TypeAlias = MutableMapping[str, JSONValue]
+

--- a/mcp_plex/common/validation.py
+++ b/mcp_plex/common/validation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import SupportsInt
 
 
 def require_positive(value: int, *, name: str) -> int:
@@ -15,9 +15,13 @@ def require_positive(value: int, *, name: str) -> int:
     return value
 
 
-def coerce_plex_tag_id(raw_id: Any) -> int:
+def coerce_plex_tag_id(raw_id: int | str | SupportsInt | None) -> int:
     """Best-effort conversion of Plex media tag identifiers to integers."""
 
+    if raw_id is None:
+        return 0
+    if isinstance(raw_id, bool):
+        return int(raw_id)
     if isinstance(raw_id, int):
         return raw_id
     if isinstance(raw_id, str):

--- a/mcp_plex/loader/__init__.py
+++ b/mcp_plex/loader/__init__.py
@@ -19,7 +19,7 @@ from qdrant_client.async_qdrant_client import AsyncQdrantClient
 from plexapi.base import PlexPartialObject as _PlexPartialObject
 from plexapi.server import PlexServer
 
-from .imdb_cache import IMDbCache, JSONValue
+from .imdb_cache import IMDbCache
 from .pipeline.channels import (
     IMDbRetryQueue,
     INGEST_DONE,
@@ -33,6 +33,7 @@ from .pipeline.persistence import PersistenceStage as _PersistenceStage
 from ..common.types import (
     AggregatedItem,
     IMDbTitle,
+    JSONValue,
     PlexGuid,
     PlexItem,
     PlexPerson,

--- a/mcp_plex/loader/imdb_cache.py
+++ b/mcp_plex/loader/imdb_cache.py
@@ -7,12 +7,7 @@ from typing import TypeAlias, cast
 
 from pydantic import ValidationError
 
-from ..common.types import IMDbTitle
-
-JSONScalar: TypeAlias = str | int | float | bool | None
-JSONValue: TypeAlias = (
-    JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
-)
+from ..common.types import IMDbTitle, JSONValue
 
 
 CachedIMDbPayload: TypeAlias = IMDbTitle | JSONValue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "1.0.18"
+version = "1.0.19"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_common_validation.py
+++ b/tests/test_common_validation.py
@@ -21,14 +21,24 @@ def test_require_positive_enforces_int_type(bad_type: object) -> None:
         require_positive(bad_type, name="value")  # type: ignore[arg-type]
 
 
-def test_coerce_plex_tag_id_accepts_ints() -> None:
-    assert coerce_plex_tag_id(7) == 7
+class _SupportsInt:
+    def __int__(self) -> int:
+        return 128
 
 
-def test_coerce_plex_tag_id_coerces_strings() -> None:
-    assert coerce_plex_tag_id(" 42 ") == 42
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (7, 7),
+        (True, 1),
+        (" 42 ", 42),
+        (_SupportsInt(), 128),
+    ],
+)
+def test_coerce_plex_tag_id_normalizes_values(raw, expected) -> None:
+    assert coerce_plex_tag_id(raw) == expected
 
 
-def test_coerce_plex_tag_id_handles_invalid_values() -> None:
-    assert coerce_plex_tag_id(None) == 0
-    assert coerce_plex_tag_id("not-a-number") == 0
+@pytest.mark.parametrize("raw", [None, "", "not-a-number"])
+def test_coerce_plex_tag_id_handles_invalid_values(raw) -> None:
+    assert coerce_plex_tag_id(raw) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "1.0.18"
+version = "1.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- add reusable JSONValue aliases for shared JSON payload structures and expose them from the common package
- refactor MediaCache, server helpers, and loader cache integrations to consume typed payload dictionaries and update validation/tests for stricter Plex tag coercion
- document the new typing expectations and bump the project version metadata

## Testing
- uv run ruff check .
- uv run pytest


------
https://chatgpt.com/codex/tasks/task_e_68e4952b6f7c83289f5605ddd75a099f