### PR TITLE
refactor(server): tighten rest typing metadata

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "1.0.22"
+version = "1.0.23"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "1.0.22"
+version = "1.0.23"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "1.0.22"
+version = "1.0.23"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- replace untyped REST/OpenAPI plumbing with helpers that generate request models and signatures without relying on Callable[..., Any] or Any return annotations
- add a typed run configuration for the CLI transport options and narrow identifier normalization inputs for cache keys
- bump the project version to 1.0.23 and refresh the uv lockfile

## Testing
- `uv run ruff check .`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e4a3d2906483289ba17f31b2bca741