### PR TITLE
refactor: tighten server typing for rest glue

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "1.0.22"
+version = "1.0.23"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "1.0.22"
+version = "1.0.23"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "1.0.22"
+version = "1.0.23"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- narrow the server request modelling helpers to avoid `Any`, use explicit parameter metadata, and shrink identifier normalization inputs
- rebuild the OpenAPI stub generation so REST and prompt routes expose typed payload signatures without depending on `Any`
- introduce a typed run configuration helper for CLI transports and exercise the new behaviour in unit tests

## Why
- cleaning up loose typing around server glue helps static analysis, avoids runtime evaluation errors, and clarifies OpenAPI payloads

## Affects
- MCP server REST/OpenAPI plumbing
- CLI transport configuration
- accompanying tests and dependency metadata

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- not needed; behaviour is covered by tests


------
https://chatgpt.com/codex/tasks/task_e_68e4a6621b0c8328a12d53cb37fd0e12