### PR TITLE
refactor(server): move typed models to dedicated module

### DIFF
--- a/mcp_plex/server/__init__.py
+++ b/mcp_plex/server/__init__.py
@@ -8,7 +8,6 @@ import json
 import logging
 import uuid
 from typing import Annotated, Any, Callable, Mapping, Sequence, TYPE_CHECKING, cast
-from typing import NotRequired, TypedDict
 
 from fastapi import FastAPI
 from fastapi.openapi.docs import get_swagger_ui_html
@@ -30,114 +29,12 @@ from rapidfuzz import fuzz, process
 from ..common.cache import MediaCache
 from ..common.types import JSONValue
 from .config import PlexPlayerAliasMap, Settings
-
-
-class PlexTag(TypedDict, total=False):
-    """Representation of a Plex tag entry (actor, director, etc.)."""
-
-    tag: NotRequired[str]
-    name: NotRequired[str]
-
-
-PersonEntry = str | PlexTag
-
-
-class ExternalIds(TypedDict, total=False):
-    """External identifier payload for indexed media."""
-
-    id: NotRequired[str | int | None]
-
-
-class PlexMediaMetadata(TypedDict, total=False):
-    """Subset of Plex metadata stored in Qdrant payloads."""
-
-    rating_key: NotRequired[str]
-    guid: NotRequired[str]
-    title: NotRequired[str]
-    type: NotRequired[str]
-    thumb: NotRequired[str]
-    art: NotRequired[str]
-    summary: NotRequired[str]
-    tagline: NotRequired[str | list[str]]
-    added_at: NotRequired[int]
-    year: NotRequired[int]
-    directors: NotRequired[list[PersonEntry]]
-    writers: NotRequired[list[PersonEntry]]
-    actors: NotRequired[list[PersonEntry]]
-    grandparent_title: NotRequired[str]
-    parent_title: NotRequired[str]
-    index: NotRequired[int]
-    parent_index: NotRequired[int]
-    grandparent_thumb: NotRequired[str]
-    original_title: NotRequired[str]
-
-
-class AggregatedMediaItem(TypedDict, total=False):
-    """Flattened media payload combining Plex and external data."""
-
-    title: NotRequired[str]
-    summary: NotRequired[str]
-    type: NotRequired[str]
-    year: NotRequired[int]
-    added_at: NotRequired[int]
-    show_title: NotRequired[str]
-    season_number: NotRequired[int]
-    episode_number: NotRequired[int]
-    tagline: NotRequired[str | list[str]]
-    reviews: NotRequired[list[str]]
-    overview: NotRequired[str]
-    plot: NotRequired[str]
-    genres: NotRequired[list[str]]
-    collections: NotRequired[list[str]]
-    actors: NotRequired[list[PersonEntry]]
-    directors: NotRequired[list[PersonEntry]]
-    writers: NotRequired[list[PersonEntry]]
-    imdb: NotRequired[ExternalIds]
-    tmdb: NotRequired[ExternalIds]
-    tvdb: NotRequired[ExternalIds]
-    plex: NotRequired[PlexMediaMetadata]
-
-
-class QdrantMediaPayload(TypedDict, total=False):
-    """Raw payload stored within Qdrant records."""
-
-    data: NotRequired[AggregatedMediaItem]
-    title: NotRequired[str]
-    summary: NotRequired[str]
-    type: NotRequired[str]
-    year: NotRequired[int]
-    added_at: NotRequired[int]
-    show_title: NotRequired[str]
-    season_number: NotRequired[int]
-    episode_number: NotRequired[int]
-    tagline: NotRequired[str | list[str]]
-    reviews: NotRequired[list[str]]
-    overview: NotRequired[str]
-    plot: NotRequired[str]
-    genres: NotRequired[list[str]]
-    collections: NotRequired[list[str]]
-    actors: NotRequired[list[PersonEntry]]
-    directors: NotRequired[list[PersonEntry]]
-    writers: NotRequired[list[PersonEntry]]
-    imdb: NotRequired[ExternalIds]
-    tmdb: NotRequired[ExternalIds]
-    tvdb: NotRequired[ExternalIds]
-    plex: NotRequired[PlexMediaMetadata]
-
-
-class PlexPlayerMetadata(TypedDict, total=False):
-    """Metadata describing a Plex player that can receive playback commands."""
-
-    name: NotRequired[str]
-    product: NotRequired[str]
-    display_name: str
-    friendly_names: list[str]
-    machine_identifier: NotRequired[str]
-    client_identifier: NotRequired[str]
-    address: NotRequired[str]
-    port: NotRequired[int]
-    provides: set[str]
-    client: NotRequired[PlexClient | None]
+from .models import (
+    AggregatedMediaItem,
+    PlexMediaMetadata,
+    PlexPlayerMetadata,
+    QdrantMediaPayload,
+)
 
 
 logger = logging.getLogger(__name__)

--- a/mcp_plex/server/models.py
+++ b/mcp_plex/server/models.py
@@ -1,0 +1,125 @@
+"""Typed models shared across the Plex server package."""
+from __future__ import annotations
+
+from typing import NotRequired, TypedDict
+
+from plexapi.client import PlexClient
+
+
+class PlexTag(TypedDict, total=False):
+    """Representation of a Plex tag entry (actor, director, etc.)."""
+
+    tag: NotRequired[str]
+    name: NotRequired[str]
+
+
+PersonEntry = str | PlexTag
+
+
+class ExternalIds(TypedDict, total=False):
+    """External identifier payload for indexed media."""
+
+    id: NotRequired[str | int | None]
+
+
+class PlexMediaMetadata(TypedDict, total=False):
+    """Subset of Plex metadata stored in Qdrant payloads."""
+
+    rating_key: NotRequired[str]
+    guid: NotRequired[str]
+    title: NotRequired[str]
+    type: NotRequired[str]
+    thumb: NotRequired[str]
+    art: NotRequired[str]
+    summary: NotRequired[str]
+    tagline: NotRequired[str | list[str]]
+    added_at: NotRequired[int]
+    year: NotRequired[int]
+    directors: NotRequired[list[PersonEntry]]
+    writers: NotRequired[list[PersonEntry]]
+    actors: NotRequired[list[PersonEntry]]
+    grandparent_title: NotRequired[str]
+    parent_title: NotRequired[str]
+    index: NotRequired[int]
+    parent_index: NotRequired[int]
+    grandparent_thumb: NotRequired[str]
+    original_title: NotRequired[str]
+
+
+class AggregatedMediaItem(TypedDict, total=False):
+    """Flattened media payload combining Plex and external data."""
+
+    title: NotRequired[str]
+    summary: NotRequired[str]
+    type: NotRequired[str]
+    year: NotRequired[int]
+    added_at: NotRequired[int]
+    show_title: NotRequired[str]
+    season_number: NotRequired[int]
+    episode_number: NotRequired[int]
+    tagline: NotRequired[str | list[str]]
+    reviews: NotRequired[list[str]]
+    overview: NotRequired[str]
+    plot: NotRequired[str]
+    genres: NotRequired[list[str]]
+    collections: NotRequired[list[str]]
+    actors: NotRequired[list[PersonEntry]]
+    directors: NotRequired[list[PersonEntry]]
+    writers: NotRequired[list[PersonEntry]]
+    imdb: NotRequired[ExternalIds]
+    tmdb: NotRequired[ExternalIds]
+    tvdb: NotRequired[ExternalIds]
+    plex: NotRequired[PlexMediaMetadata]
+
+
+class QdrantMediaPayload(TypedDict, total=False):
+    """Raw payload stored within Qdrant records."""
+
+    data: NotRequired[AggregatedMediaItem]
+    title: NotRequired[str]
+    summary: NotRequired[str]
+    type: NotRequired[str]
+    year: NotRequired[int]
+    added_at: NotRequired[int]
+    show_title: NotRequired[str]
+    season_number: NotRequired[int]
+    episode_number: NotRequired[int]
+    tagline: NotRequired[str | list[str]]
+    reviews: NotRequired[list[str]]
+    overview: NotRequired[str]
+    plot: NotRequired[str]
+    genres: NotRequired[list[str]]
+    collections: NotRequired[list[str]]
+    actors: NotRequired[list[PersonEntry]]
+    directors: NotRequired[list[PersonEntry]]
+    writers: NotRequired[list[PersonEntry]]
+    imdb: NotRequired[ExternalIds]
+    tmdb: NotRequired[ExternalIds]
+    tvdb: NotRequired[ExternalIds]
+    plex: NotRequired[PlexMediaMetadata]
+
+
+class PlexPlayerMetadata(TypedDict, total=False):
+    """Metadata describing a Plex player that can receive playback commands."""
+
+    name: NotRequired[str]
+    product: NotRequired[str]
+    display_name: str
+    friendly_names: list[str]
+    machine_identifier: NotRequired[str]
+    client_identifier: NotRequired[str]
+    address: NotRequired[str]
+    port: NotRequired[int]
+    provides: set[str]
+    client: NotRequired[PlexClient | None]
+
+
+__all__ = [
+    "PlexTag",
+    "PersonEntry",
+    "ExternalIds",
+    "PlexMediaMetadata",
+    "AggregatedMediaItem",
+    "QdrantMediaPayload",
+    "PlexPlayerMetadata",
+]


### PR DESCRIPTION
## What
- move the TypedDict definitions from `mcp_plex/server/__init__.py` into a new `mcp_plex/server/models.py`
- import the shared models from the new module and remove redundant typing imports in the server package entrypoint

## Why
- keep the server entrypoint focused on runtime logic and centralize shared typing structures in a dedicated module for reuse

## Affects
- `mcp_plex/server/__init__.py`
- `mcp_plex/server/models.py`

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Documentation
- not needed

------
https://chatgpt.com/codex/tasks/task_e_68e4b849ed3883288e133883189ba1c8