### PR TITLE
feat(loader): extract sample data helpers

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "2.0.3"
+version = "2.0.4"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/loader/samples.py
+++ b/mcp_plex/loader/samples.py
@@ -1,0 +1,148 @@
+"""Helpers for working with built-in sample data files."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from ..common.types import (
+    AggregatedItem,
+    IMDbTitle,
+    PlexGuid,
+    PlexItem,
+    PlexPerson,
+    TMDBMovie,
+    TMDBShow,
+)
+from ..common.validation import coerce_plex_tag_id
+
+
+def _read_json(path: Path) -> Any:
+    """Return parsed JSON content from ``path``."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _load_people(
+    entries: Iterable[dict[str, Any]] | None,
+    *,
+    include_role: bool,
+) -> list[PlexPerson]:
+    """Construct :class:`PlexPerson` objects from Plex JSON entries."""
+
+    people: list[PlexPerson] = []
+    for entry in entries or []:
+        person_kwargs: dict[str, Any] = {
+            "id": coerce_plex_tag_id(entry.get("id", 0)),
+            "tag": entry.get("tag", ""),
+            "thumb": entry.get("thumb"),
+        }
+        if include_role:
+            person_kwargs["role"] = entry.get("role")
+        people.append(PlexPerson(**person_kwargs))
+    return people
+
+
+def _load_collections(data: dict[str, Any]) -> list[str]:
+    """Extract collection tags from Plex metadata."""
+
+    collections: list[str] = []
+    for key in ("Collection", "Collections"):
+        entries = data.get(key) or []
+        for entry in entries:
+            tag = entry.get("tag")
+            if tag:
+                collections.append(tag)
+    return collections
+
+
+def _load_plex_movie(data: dict[str, Any]) -> PlexItem:
+    """Build a :class:`PlexItem` for the sample movie."""
+
+    return PlexItem(
+        rating_key=str(data.get("ratingKey", "")),
+        guid=str(data.get("guid", "")),
+        type=data.get("type", "movie"),
+        title=data.get("title", ""),
+        summary=data.get("summary"),
+        year=data.get("year"),
+        added_at=data.get("addedAt"),
+        guids=[PlexGuid(id=str(guid.get("id", ""))) for guid in data.get("Guid", []) or []],
+        thumb=data.get("thumb"),
+        art=data.get("art"),
+        tagline=data.get("tagline"),
+        content_rating=data.get("contentRating"),
+        directors=_load_people(data.get("Director"), include_role=False),
+        writers=_load_people(data.get("Writer"), include_role=False),
+        actors=_load_people(data.get("Role"), include_role=True),
+        genres=[
+            genre.get("tag", "")
+            for genre in data.get("Genre", []) or []
+            if genre.get("tag")
+        ],
+        collections=_load_collections(data),
+    )
+
+
+def _load_plex_episode(data: dict[str, Any]) -> PlexItem:
+    """Build a :class:`PlexItem` for the sample episode."""
+
+    return PlexItem(
+        rating_key=str(data.get("ratingKey", "")),
+        guid=str(data.get("guid", "")),
+        type=data.get("type", "episode"),
+        title=data.get("title", ""),
+        show_title=data.get("grandparentTitle"),
+        season_title=data.get("parentTitle"),
+        season_number=data.get("parentIndex"),
+        episode_number=data.get("index"),
+        summary=data.get("summary"),
+        year=data.get("year"),
+        added_at=data.get("addedAt"),
+        guids=[PlexGuid(id=str(guid.get("id", ""))) for guid in data.get("Guid", []) or []],
+        thumb=data.get("thumb"),
+        art=data.get("art"),
+        tagline=data.get("tagline"),
+        content_rating=data.get("contentRating"),
+        directors=_load_people(data.get("Director"), include_role=False),
+        writers=_load_people(data.get("Writer"), include_role=False),
+        actors=_load_people(data.get("Role"), include_role=True),
+        genres=[
+            genre.get("tag", "")
+            for genre in data.get("Genre", []) or []
+            if genre.get("tag")
+        ],
+        collections=_load_collections(data),
+    )
+
+
+def _load_from_sample(sample_dir: Path) -> list[AggregatedItem]:
+    """Load items from local sample JSON files."""
+
+    movie_dir = sample_dir / "movie"
+    episode_dir = sample_dir / "episode"
+
+    movie_data = _read_json(movie_dir / "plex.json")["MediaContainer"]["Metadata"][0]
+    imdb_movie = IMDbTitle.model_validate(_read_json(movie_dir / "imdb.json"))
+    tmdb_movie = TMDBMovie.model_validate(_read_json(movie_dir / "tmdb.json"))
+
+    episode_data = _read_json(episode_dir / "plex.tv.json")["MediaContainer"]["Metadata"][0]
+    imdb_episode = IMDbTitle.model_validate(_read_json(episode_dir / "imdb.tv.json"))
+    tmdb_show = TMDBShow.model_validate(_read_json(episode_dir / "tmdb.tv.json"))
+
+    return [
+        AggregatedItem(
+            plex=_load_plex_movie(movie_data),
+            imdb=imdb_movie,
+            tmdb=tmdb_movie,
+        ),
+        AggregatedItem(
+            plex=_load_plex_episode(episode_data),
+            imdb=imdb_episode,
+            tmdb=tmdb_show,
+        ),
+    ]
+
+
+__all__ = ["_load_from_sample"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "2.0.3"
+version = "2.0.4"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_loader_unit.py
+++ b/tests/test_loader_unit.py
@@ -17,7 +17,6 @@ from mcp_plex.loader import (
     QdrantRuntimeConfig,
     _build_loader_orchestrator,
     _fetch_imdb,
-    _load_from_sample,
     _load_imdb_retry_queue,
     _persist_imdb_retry_queue,
     _process_imdb_retry_queue,
@@ -30,6 +29,7 @@ from mcp_plex.loader.qdrant import (
     build_point,
 )
 from mcp_plex.loader.pipeline.channels import IMDbRetryQueue
+from mcp_plex.loader import samples as loader_samples
 from mcp_plex.common.types import (
     AggregatedItem,
     IMDbName,
@@ -83,7 +83,7 @@ def test_loader_import_requires_plexapi(monkeypatch):
     assert not hasattr(module, "PartialPlexObject")
 def test_load_from_sample_returns_items():
     sample_dir = Path(__file__).resolve().parents[1] / "sample-data"
-    items = _load_from_sample(sample_dir)
+    items = loader_samples._load_from_sample(sample_dir)
     assert len(items) == 2
     assert {i.plex.type for i in items} == {"movie", "episode"}
 
@@ -434,7 +434,7 @@ def test_build_point_includes_metadata():
 
 
 def test_loader_pipeline_processes_sample_batches(monkeypatch):
-    sample_items = _load_from_sample(
+    sample_items = loader_samples._load_from_sample(
         Path(__file__).resolve().parents[1] / "sample-data"
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "2.0.3"
+version = "2.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- move the sample loading helper into `mcp_plex.loader.samples` and import it from the loader package
- update sample-mode tests to import the new module directly and exercise its helpers
- bump the project version metadata to 2.0.4

## Why
- allow the staged loader orchestrator and tests to share the sample loader helpers while giving the module direct coverage

## Affects
- loader sample ingestion helpers, loader package exports, and sample-mode unit tests

## Testing
- uv run ruff check .
- uv run pytest

## Documentation
- not needed

------
https://chatgpt.com/codex/tasks/task_e_68e4ce4838f48328b987f9a1a3c76388