### PR TITLE
Ensure IMDb retry queue path exists before persisting

### DIFF
--- a/docker/pyproject.deps.toml
+++ b/docker/pyproject.deps.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-plex"
-version = "2.0.6"
+version = "2.0.7"
 requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastmcp>=2.11.2",

--- a/mcp_plex/loader/__init__.py
+++ b/mcp_plex/loader/__init__.py
@@ -163,6 +163,7 @@ async def _process_imdb_retry_queue(
 def _persist_imdb_retry_queue(path: Path, queue: IMDbRetryQueue) -> None:
     """Persist the retry queue to disk."""
 
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(queue.snapshot()))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-plex"
-version = "2.0.6"
+version = "2.0.7"
 
 description = "Plex-Oriented Model Context Protocol Server"
 requires-python = ">=3.11,<3.13"

--- a/tests/test_loader_unit.py
+++ b/tests/test_loader_unit.py
@@ -358,10 +358,11 @@ def test_imdb_retry_queue_desync_errors():
 
 
 def test_persist_imdb_retry_queue_writes_snapshot(tmp_path):
-    path = tmp_path / "retry.json"
+    path = tmp_path / "nested" / "dirs" / "retry.json"
     queue = IMDbRetryQueue(["tt1"])
     _persist_imdb_retry_queue(path, queue)
     assert json.loads(path.read_text()) == ["tt1"]
+    assert path.exists()
 
 
 def test_ensure_collection_skips_existing():

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "mcp-plex"
-version = "2.0.6"
+version = "2.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What
- create the parent directory for the IMDb retry queue file before writing it
- update the loader unit test to cover persistence into a nested directory
- bump the project version to 2.0.7 and refresh the dependency lock file

## Why
- persisting the retry queue failed when the configured path included missing parent directories, preventing retry state from being saved

## Affects
- loader retry queue persistence
- project version metadata

## Testing
- uv run pytest

## Documentation
- none needed

------
https://chatgpt.com/codex/tasks/task_e_68e4de5f1f7c8328bade78c5d42468e1